### PR TITLE
feat(triage): add triage plugin to the marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,6 +17,12 @@
       "version": "2.1.0",
       "source": "./plugins/scrum-toolkit",
       "description": "Full SCRUM lifecycle toolkit — ceremonies, PM/PO authoring, and DevOps actions with GitHub integration"
+    },
+    {
+      "name": "triage",
+      "version": "1.0.0",
+      "source": "./plugins/triage",
+      "description": "Advisory task classifier that routes tasks to the best available skill, agent, or MCP server."
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## triage 1.0.0 (new plugin)
+
+- feat(triage): add /triage advisory task classifier — classifies a natural-language task into a workflow shape and maps each phase to the best installed skill, agent, or MCP server
+- feat(triage): MCP-server discovery across project `.mcp.json`, `~/.claude.json` per-project entry, and plugin `.mcp.json` (wrapped and bare-map forms)
+- feat(triage): cross-platform node-only helper scripts (`.mjs`) — no shell/jq/awk/sed/yq/python dependency
+- test(triage): node:test parity + MCP fixture suite (24 tests, zero deps); first claude-salad plugin to ship runtime scripts + tests
+- chore: lift the marketplace's pure-markdown-only rule to allow minimal runtime scripts and self-contained tests
+
 ## config-doctor 1.2.0 → 1.3.0
 
 - feat(bootstrap): add /bootstrap skill for day-0 Claude Code project setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-claude-salad is a multi-plugin marketplace for Claude Code. No build step or test suite — content is markdown files executed by Claude Code.
+claude-salad is a multi-plugin marketplace for Claude Code. Most plugins are pure markdown executed by Claude Code; a plugin MAY ship runtime helper scripts (e.g. Node `.mjs`) and its own self-contained test suite when its skill needs executable logic (see `plugins/triage`).
 
 ## Lint
 
@@ -23,6 +23,8 @@ plugins/<plugin-name>/    # Each plugin is self-contained
   CLAUDE.md               # Plugin-specific conventions (agent frontmatter, skill flags, etc.)
   agents/                 # Agent definitions — deployed to user's .claude/agents/ on install
   skills/                 # Skill definitions (not all plugins have skills)
+  scripts/ or test/       # Optional — runtime helper scripts + their tests, for plugins with executable logic
+  package.json            # Optional — only for plugins that ship a Node test suite (e.g. triage)
 ```
 
 ## Conventions
@@ -30,6 +32,6 @@ plugins/<plugin-name>/    # Each plugin is self-contained
 - **Plugin independence**: each plugin under `plugins/` is fully self-contained with its own CLAUDE.md, agents, skills, and plugin.json. No shared agents across plugins.
 - **Version sync**: a plugin's version appears in three places that must stay in sync — `plugins/<name>/.claude-plugin/plugin.json` (source of truth), the matching entry in `.claude-plugin/marketplace.json`, and any `version:` field in skill frontmatter. Update all three together.
 - **Agent frontmatter**: every agent `.md` file requires `name:`, `description:` (with `<example>` blocks), and `model:` fields in YAML frontmatter. See each plugin's CLAUDE.md for model assignments.
-- **No build artifacts**: do not introduce package managers, build tools, or compiled assets. This marketplace is pure markdown.
+- **Runtime scripts & tests are allowed**: a plugin may ship runtime helper scripts (Node `.mjs`, no transpile step) and a self-contained test suite (`node --test`, zero deps) when its skill needs executable logic. Keep them minimal and dependency-free — avoid heavyweight build tooling, bundlers, or compiled artifacts. Markdown-only plugins remain the norm.
 - **Markdown lint**: all markdown files are validated by CI. Run `npx markdownlint-cli2 "**/*.md"` locally before pushing.
 - **Plugin-level conventions**: see each plugin's own `CLAUDE.md` for plugin-specific rules (skill flags, subagent dispatch patterns, etc.).

--- a/plugins/triage/.claude-plugin/plugin.json
+++ b/plugins/triage/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "triage",
+  "version": "1.0.0",
+  "description": "Advisory task classifier — reads your installed skills, agents, and MCP servers, classifies a task into a workflow shape, and maps each phase to the best available invocation. Never dispatches agents or edits code.",
+  "author": { "name": "mpiccinnonode" },
+  "repository": "https://github.com/mpiccinnonode/claude-salad",
+  "license": "MIT",
+  "keywords": ["triage", "routing", "skills", "workflow", "onboarding", "mcp"]
+}

--- a/plugins/triage/CLAUDE.md
+++ b/plugins/triage/CLAUDE.md
@@ -1,0 +1,9 @@
+# triage plugin — dev notes
+
+Single-skill plugin packaging the `/triage` classifier.
+
+- Skill body: `skills/triage/SKILL.md`. In-plugin paths use `${CLAUDE_PLUGIN_ROOT}`.
+- Helper scripts: `skills/triage/scripts/*.mjs` — Node only, no shell/jq/python/yq.
+- Each script has a fixed argv signature + stdout contract documented in its header. Three were ported 1:1 from POSIX `.sh`; parity is locked by golden-output tests in `test/`.
+- `discover-skills.mjs` additionally discovers MCP servers (project `.mcp.json`, `~/.claude.json` per-project entry, and plugin `.mcp.json`).
+- Run tests: `npm test` (uses node:test, no deps).

--- a/plugins/triage/README.md
+++ b/plugins/triage/README.md
@@ -1,0 +1,22 @@
+# triage
+
+Advisory task classifier for Claude Code. Describe a task in natural language and `/triage` classifies it into a workflow shape, then maps each phase to the best-matching skill, agent, or MCP server you actually have installed — or emits a copy-pasteable prompt when nothing matches.
+
+## Requirements
+
+- **Node ≥ 18** (the only runtime dependency; all helper scripts are Node — no shell, jq, python, or yq needed).
+
+## Install
+
+```text
+/plugin marketplace add mpiccinnonode/claude-salad
+/plugin install triage@mpiccinnonode
+```
+
+## Usage
+
+```text
+/triage <task description>
+```
+
+Triage never dispatches agents or edits code — it recommends and records a triage decision at `.claude/triage/<slug>.yaml` in your project.

--- a/plugins/triage/package.json
+++ b/plugins/triage/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "triage-plugin",
+  "version": "1.0.0",
+  "description": "Advisory task classifier that routes natural-language tasks to the right installed skill, agent, or MCP server.",
+  "private": true,
+  "type": "module",
+  "engines": { "node": ">=18" },
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/plugins/triage/skills/triage/SKILL.md
+++ b/plugins/triage/skills/triage/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: triage
+description: Use when the user describes a task in natural language without specifying which skill to invoke, is unsure which skill to use, or is onboarding to a project with a defined skill vocabulary. Trigger on phrases like "I need to...", "how do I...", "where do I start with...", "what skill should I use for...", or any task description that implies ambiguity about the right workflow. Trigger when the user's request lacks a specific skill invocation AND the task type is not obvious from context.
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Write
+argument-hint: "[task description in natural language]"
+---
+
+# Triage Skill
+
+Advisory classifier — reads the user's configured skills/agents, classifies the task into a workflow shape, then maps each phase of that shape to the best-matching invocation available in the current environment. Never dispatches agents. Never begins implementation.
+
+## Core Concept
+
+Triage is a **two-step translator**, not a hardcoded routing table:
+
+1. **Classification → Abstract phase sequence** (a universal workflow shape: Exploration, Planning, Implementation, Debugging, Fix, Design Work, Review)
+2. **Abstract phases → Concrete invocations** (dynamically matched from whatever skills and agents the user actually has)
+
+This SKILL.md never names specific downstream skills. A skill whose description talks about exploring intent and requirements is a candidate for the Exploration phase. A skill whose description mentions writing an implementation plan, decomposing work, or authoring a spec is a candidate for Planning. The mapping is computed each invocation from whatever is currently discovered — not baked into this prompt. If no skill matches a phase, triage emits a **generic prompt fallback** — a copy-pasteable instruction the user can run directly.
+
+The goal: the same triage skill produces sensible recommendations regardless of which skill packages, plugin namespaces, or bespoke team workflows the user has installed — or whether they have none at all.
+
+**Persistence model:** each triage is recorded as a YAML file at `.claude/triage/<slug>.yaml` (or user-global fallback), making triage decisions **versioned project artifacts** — visible in PR review, survivable across machines, and retrievable by future sessions via a deterministic script.
+
+---
+
+## Phase 1 — Context & Config Discovery
+
+If `$ARGUMENTS` is empty, ask "What are you trying to do?" before proceeding. Otherwise treat `$ARGUMENTS` as the task description.
+
+### 1a. Check for active triages (short-circuit on match)
+
+Before anything else, look for an existing triage on this same task so we don't duplicate planning across sessions:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/triage-recall.mjs" \
+  --dir "$(node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" --root "$(pwd)" --home "$HOME" --path-only)" \
+  --find "<2-4 key words from the task description>" \
+  --json
+```
+
+If `triage-recall.mjs` returns a record whose `task` is a strong semantic match for `$ARGUMENTS`:
+
+- Show the existing record and its phase statuses to the user.
+- Ask: "This looks like the triage we ran on `<date>`. Resume it, or start a new one?"
+- If resume: skip to Phase 5, emit the existing record's Recommended Invocations, and jump to the first `pending` phase.
+- If new: continue to Phase 1b.
+
+If the resolve script returns `{"path":null}`, skip the active check silently — there's nowhere to persist, so there's nowhere to recall from either. Continue to Phase 1b.
+
+### 1b. Candidate list (offloaded)
+
+Invoke the discovery script to build the skills+agents candidate list across all three scopes:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/discover-skills.mjs" "$(pwd)" "$HOME"
+```
+
+`$(pwd)` is the current project root; `$HOME` is the user's home directory. Both must resolve to absolute paths. The script itself validates absoluteness and exits 2 on failure.
+
+The script emits a JSON array of `{ scope, kind, name, description, path }` on stdout, where:
+
+- `scope` ∈ `project-local` | `user-global` | `plugin-installed`
+- `kind` ∈ `skill` | `agent` | `mcp-server`
+
+This array is the input to Phase 4's mapping. Do not re-glob, re-read SKILL.md frontmatter, or re-parse YAML in the skill body — the script is the single source of truth.
+
+**On non-zero exit:** surface the script's stderr diagnostic to the user and halt. Do not fall back to inline traversal — a failed script means the frontmatter is malformed or the environment is broken, and silent fallback would mask the regression the offload was meant to expose (see `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/offload-scripts.md` §Exit codes).
+
+### 1c. Context reads (inline)
+
+These are not globs and stay in the skill body. Read in this order and stop at the first missing item for project-specific reads; always read the user-global entry:
+
+1. `CLAUDE.md` at project root — project type, stack, conventions, mentioned skills.
+2. Open specs — invoke the script and consume its JSON:
+
+   ```bash
+   node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/find-open-specs.mjs" --root "$(pwd)"
+   ```
+
+   Contract: stdout JSON array of `{"slug": "<basename-minus-md>", "path": "<abs-path>"}`; empty array if `specs/` is missing. Non-zero + stderr on missing/relative `--root`. Halt and surface the diagnostic on non-zero; do not fall back to inline globbing.
+
+3. `git log --oneline -5` — active area of codebase.
+4. `~/.claude/CLAUDE.md` — user-global instructions (always read).
+
+Project-local items stop on first miss: if no `CLAUDE.md` exists, skip straight to the user-global read; the candidate list from 1b still provides project-local skills and agents if they exist.
+
+---
+
+## Phase 2 — Classify
+
+Map the task description to exactly one type:
+
+| Classification | Signals |
+|---|---|
+| **UI Feature** | New page, component, significant template change, layout/interaction work with no significant data layer change |
+| **Logic Feature** | New service, store, data layer, API integration, background job — no significant UI |
+| **Mixed Feature** | New data flow AND new/modified UI to display it |
+| **Bug Fix** | Something broken, unexpected behavior, regression, error message, flaky test |
+| **Refactor** | Restructuring existing code without behavior change |
+| **Design** | UI/visual design work only — design tokens, component library authorship, mockups, Figma files. Requirements/intent exploration for a Feature is NOT Design — that's the Exploration phase of a Feature. |
+| **Review** | Code or UX review of existing/completed work |
+| **Other** | Doesn't fit above → ask one clarifying question, don't guess |
+
+**Ambiguity signals to flag before classifying:**
+
+- Description mixes UI terms and logic/service terms → consider Mixed or ask
+- Bug touches components with mobile-framework prefixes (e.g., `ion-*`, `Native*`) → Bug Fix, note possible mobile-compat consideration
+- Requested refactor or feature touches a file referenced in an open spec → flag the conflict
+
+---
+
+## Phase 3 — Derive the Abstract Flow
+
+Every classification maps to a fixed sequence of **abstract phases**. Phases are conceptual — they describe the kind of thinking the work needs, not the command to run.
+
+| Classification | Abstract Flow |
+|---|---|
+| UI / Logic / Mixed Feature | Exploration → Planning → Implementation → Review |
+| Refactor | Exploration → Planning → Implementation → Review |
+| Bug Fix | Debugging → Fix → Review |
+| Design | Exploration → Design Work → Planning → Implementation → Review |
+| Review | Review |
+| Other | (determined after clarification) |
+
+### Why Exploration is load-bearing for Features and Refactors
+
+Any creative work — creating features, building components, adding functionality, modifying behavior, or restructuring existing code — depends on first aligning on intent, constraints, prior art, and preferred patterns. This phase is not a ceremony; its absence means implementing the wrong thing or picking an idiom the project already rejected. For a refactor specifically, Exploration is where "ask about preferred patterns and prior art before proposing" lives.
+
+**Self-evident scope exception:** If the task is clearly trivial (copy change, single-token color swap, one-line bug-fix equivalent), still list Exploration but annotate it **`(optional — scope is self-evident)`** and explain that it's available as a sanity check if the user suspects hidden scope. Never silently drop it.
+
+---
+
+## Phase 4 — Map Abstract Phases to Concrete Invocations
+
+For each phase in the derived flow, find the **best-matching skill or agent** from the candidate list built in Phase 1b. Match by the **intent** expressed in the skill's description — not by literal substring match on skill names.
+
+**Intent signals per abstract phase:**
+
+| Phase | Match on descriptions mentioning… |
+|---|---|
+| **Exploration** | brainstorm, intent, requirements, scope, options, pre-implementation, stress-test, poking holes, pressure-test, adversarial review of a spec |
+| **Planning** | writing plan, spec author, decomposition, phased implementation plan, sprint plan, roadmap, user story with acceptance criteria |
+| **Implementation** | executing a plan, test-driven workflow, feature build, implement-from-spec, parallel subagent execution, code generation |
+| **Debugging** | systematic debugging, root cause, diagnose, bug investigation |
+| **Fix** | code edit, applied fix, regression patch (often this is "use direct editing tools" — no dedicated skill needed) |
+| **Design Work** | visual design, design tokens, component library authoring, mockups, UI produced from a design spec |
+| **Review** | code review, PR review, standards check, verification before completion |
+
+**Tie-breaking** when multiple skills match the same phase:
+
+1. Prefer project-local skills (`.claude/skills/`) over user-global over plugin-installed
+2. Prefer skills whose description names the workflow context more precisely (a description that says "authors a phased implementation plan" is a stronger Planning match than one that only mentions "planning" in passing)
+3. If still ambiguous, record **both** — one as `skill`, the second as `alternative` — so the Phase 5 output can surface the tie-breaker visibly instead of silently dropping the loser
+
+**Fallback when no skill matches a phase** — emit a generic prompt the user can paste directly. The prompt should describe the phase's goal in one or two sentences and ask Claude to execute that phase specifically. Example scaffold (fill in the phase-specific part):
+
+> `No matching skill found for [Phase]. Paste this into Claude:`
+> `"[one-sentence description of what this phase should accomplish for the user's task]"`
+
+**Open specs:** If `specs/<slug>.md` matches the described task, add a note that Implementation can be invoked directly against the spec (in whatever way the mapped Implementation skill supports, or via a generic "implement specs/<slug>.md" prompt).
+
+### Second pass — Tool-shaped supporting skills
+
+Some skills aren't phase-shaped. They're tools that augment whichever phase the user is in: a code-structure search skill speeds up Exploration, Debugging, and Implementation alike; a library-docs lookup fires whenever the task touches a named framework. After the per-phase mapping above, run a second pass against the same candidate list using these intent signals:
+
+| Tool shape | Match on descriptions mentioning… |
+|---|---|
+| **Code understanding** | code structure search, AST traversal, symbol lookup, "instead of reading full files", structural code exploration, tree-sitter |
+| **Library docs** | library/framework/SDK documentation, API syntax lookup, version migration, library-specific debugging, "use when user asks about <lib>" |
+| **Memory recall** | persistent cross-session memory, prior-session lookup, "did we solve this before", cross-session search |
+| **MCP server** | any discovered `kind: "mcp-server"` record — match the server **name** (and `description` when present) to the shape it serves: docs servers (e.g. context7) → Library docs; memory servers (e.g. claude-mem) → Memory recall; code-graph/review servers (e.g. code-review-graph) → Code understanding / Review |
+
+**MCP servers are discovered, not assumed.** `discover-skills.mjs` emits `kind: "mcp-server"` records from the project `.mcp.json`, the user's `~/.claude.json` (this project's entry), and any installed plugin's `.mcp.json`. A server shipped by a plugin — e.g. a `code-review-graph` plugin — is therefore surfaced automatically with no plugin-specific knowledge baked into this skill. **Limitation:** discovery is server-level. The candidate record carries the server's name and (when the config provides one) its description — not its individual tool schemas, which are only available at runtime. Surface the server in the **Supporting Skills** block by name; do not claim specific tools it may expose.
+
+Surface every match in the recommendation's **Supporting Skills** block. Tool-shaped skills are not part of the phase sequence — they don't get tie-broken against phase matches and they don't get the generic-prompt fallback (if no tool-shaped skill matches a given shape, simply omit that shape from the block).
+
+For each match, write a one-sentence trigger condition tailored to *this task* (e.g., "fires when locating the existing auth middleware before editing it" — not the skill's generic description).
+
+---
+
+## Phase 5 — Recommend
+
+For unambiguous tasks, output the recommendation immediately — no confirmation gate before display.
+For ambiguous tasks, ask exactly one clarifying question, then recommend.
+For low-confidence tasks, surface both plausible interpretations and ask the user to choose.
+
+**Confidence calibration:**
+
+- **High** — task maps cleanly to one type with no meaningful alternative reading
+- **Medium** — classifiable but has meaningful alternative interpretations (e.g., Mixed Feature where it's unclear if the data layer already exists)
+- **Low** — two interpretations are roughly equally plausible → surface both, ask user to choose
+
+Mixed Features should almost always be Medium — the whole point of the classification is that it straddles concerns, and which layer to start from is a real choice.
+
+**Output format:**
+
+```text
+## Task: [task description]
+**Classification:** [type]
+**Confidence:** High / Medium / Low
+
+### Abstract Flow
+[phase] → [phase] → [phase] → [phase]
+
+### Recommended Invocations
+1. **[Phase]** — [mapped skill/agent invocation, or generic prompt fallback]
+   _Alternative: [secondary skill] — use if [one-sentence discriminator]_   ← only if tie-breaker produced one
+2. **[Phase]** — ...
+3. **[Phase]** — ...
+4. **[Phase]** — ...
+
+### Supporting Skills   ← omit entire section if no tool-shaped skills matched
+- **[skill]** — [one-sentence trigger condition for this task — when it would fire and what it would speed up]
+- **[skill]** — ...
+
+### Why This Flow
+[1-2 sentences: classification reasoning + what makes these phases load-bearing for this task. Mention any flags from Phase 2 signals here.]
+
+### If I Misclassified
+[alternative type] → [alternative flow summary with mapped invocations]
+```
+
+**Flagging open specs:** If a matching open spec was found, add:
+
+```text
+⚠️ Open spec: specs/<slug>.md — Implementation can be run against this directly.
+```
+
+**No skills configured:** If Phase 1b discovered zero skills and zero agents, output only the abstract flow with a generic prompt for each phase. Keep it actionable — the user should be able to copy-paste any step into Claude and make progress.
+
+---
+
+## Phase 6 — Persist the Triage Record
+
+Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`. This is how cross-session retrieval works — a future session invokes `triage-recall.mjs` (Phase 1a) and finds the record that this phase wrote.
+
+### When to fire Phase 6
+
+- **High confidence** → fire automatically, immediately after Phase 5 output. Write with `status: draft` and the filename suffix `.draft.yaml`. The draft exists so nothing is lost if the user walks away; it's explicitly marked so it doesn't pollute `--active` results as a decided plan.
+- **Medium / Low confidence** → wait for the user to pick an interpretation (from the "If I Misclassified" block or the two-interpretation surface), then fire with `status: draft`.
+
+### Confirmation gate (promotes draft → in_progress)
+
+After the draft is written, tell the user:
+
+> `Saved as draft at <path>. Say "confirmed" (or start running the first recommended command) to promote to in_progress.`
+
+On confirmation — or when the user's next message clearly proceeds with the flow (e.g., invoking the first recommended skill) — rename `<slug>.draft.yaml` → `<slug>.yaml` and flip `status: draft` → `status: in_progress`. This two-step design prevents the old "user skipped confirmation ⇒ nothing saved" leak while keeping drafts distinguishable in git diffs and in recall.
+
+### Resolving the storage path
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" --root "$(pwd)" --home "$HOME"
+```
+
+Contract: stdout JSON, one of:
+
+- `{"path":"<abs>","scope":"project"}` — preferred; versioned with the project. If the directory doesn't exist yet, create it with `mkdir -p` before writing.
+- `{"path":"<abs>","scope":"user"}` — fallback when the project has no `.claude/` dir.
+- `{"path":null,"scope":null}` — nothing configured; **skip Phase 6 silently**. Do not attempt to create `.claude/` in the project — that's a project-config decision, not a triage decision.
+
+Non-zero + stderr on missing/relative `--root` or `--home`. Halt on non-zero and surface the diagnostic.
+
+### Slug derivation
+
+- Lowercase, hyphen-separated, max 50 chars, stripped of punctuation.
+- If `<slug>.yaml` or `<slug>.draft.yaml` already exists for an unrelated task, append `-2`, `-3`, etc.
+
+### File contents
+
+Write the file using the schema in `references/triage-schema.md` — that document is the source of truth for fields, lifecycle states, and invariants. Read it before writing.
+
+### After writing
+
+- Output the exact first command to copy-paste and stop.
+- Do not begin implementation.
+- Do not add an entry to MEMORY.md — the triage directory is the index, reached through `triage-recall.mjs`.
+
+---
+
+## Constraints
+
+- Never dispatches agents or modifies source code files
+- Never hardcodes downstream skill names in this SKILL.md — concrete invocations are always derived from the user's current discovered config
+- Works on projects with zero `.claude/` config (graceful degradation via generic prompt fallbacks; Phase 6 silently skips persistence)
+- Never blocks on confirmation for unambiguous tasks (Phase 5 outputs immediately; Phase 6 writes a draft immediately)
+- File writes are limited to `<triage-dir>/<slug>.yaml` and `<slug>.draft.yaml` only — no other paths
+- **Never read `.claude/triage/` directly** (no inline `ls`, `Glob`, or `find`). The only read path is `scripts/triage-recall.mjs`, which enforces a stable contract so future sessions can rely on it
+- Output must be immediately actionable — copy-pasteable commands or prompts, no assumed knowledge
+- Exploration must never be silently dropped for Feature or Refactor classifications; for trivial scope, mark it optional but still surface it

--- a/plugins/triage/skills/triage/references/offload-scripts.md
+++ b/plugins/triage/skills/triage/references/offload-scripts.md
@@ -1,0 +1,74 @@
+# Offload Scripts — Contract
+
+**Status:** Active
+**Established:** 2026-04-22
+**Scope:** Scripts that offload deterministic work from skill bodies to colocated executables. Governs the files introduced by the Script Offloading plan (`~/.claude/plans/2026-04-21-script-offloading-plan.md`).
+
+---
+
+## Location
+
+Scripts live **inside the owning skill's folder**:
+
+```text
+~/.claude/skills/<skill>/scripts/<operation>.sh
+~/.claude/skills/<skill>/scripts/<operation>.mjs
+```
+
+A script is only ever called by its owning SKILL.md. Cross-skill calls are forbidden — if two skills need the same logic, each gets its own copy. This keeps the skill folder the unit of audit, revert, and removal.
+
+## Extension choice
+
+- `.sh` — pure glob / grep / `wc` / shell arithmetic / `jq` one-liners.
+- `.mjs` — YAML parsing, structured text manipulation, JSON emission more complex than a single `jq` expression. Node is assumed available (see spec §1.5).
+
+Borderline cases get decided at authoring time. Do not introduce other runtimes.
+
+## Header
+
+Every script begins with a one-line comment naming the SKILL.md section it serves. This is the only explicit link between script and skill body and makes the pair auditable at grep-speed.
+
+```sh
+# Serves: code-review SKILL.md — Phase 0 Lifecycle Pass (§1.2.1)
+```
+
+```js
+// Serves: distill SKILL.md — Consolidate Mode, Prune Candidates (§1.2.10)
+```
+
+## Inputs
+
+- **argv only.** No environment-variable reads. Per-project configuration, if ever needed, must be passed via argv by the skill body.
+- Inputs that are file paths must be absolute or resolved from argv before use. No implicit `cwd` assumptions.
+
+## Output
+
+- **stdout:** a JSON object for structured payloads; a single-line string for scalar results; **nothing else**. No progress logs, no banners, no trailing newlines beyond one.
+- **stderr:** reserved for a one-line diagnostic when exiting non-zero. Silent on success.
+
+## Exit codes
+
+- `0` — success. stdout contains the payload.
+- Any non-zero — failure. stderr contains one diagnostic line. The skill body **must halt and surface the diagnostic**; it must not silently fall back to the pre-offload path (see plan Cross-cutting → Failure handling).
+
+Empty/malformed input is a failure, not a zero-value success. Example: a recurrence-count script receiving empty input exits non-zero; it does not emit `{count: 0}`.
+
+## Idempotency
+
+Where the pre-offload skill body is idempotent, the script must be too. Re-running on already-processed input is a no-op: no filesystem mutations, stable output. Idempotency is verified as part of each slice's stop gate where applicable (see plan Slice 4).
+
+## What scripts must not do
+
+- Call other scripts in other skills' folders.
+- Mutate state outside the skill folder or the explicit file paths passed via argv.
+- Read from the environment.
+- Write to stdout on failure, or to stderr on success.
+- Invoke the LLM or any agent. Scripts are deterministic or they do not belong here.
+
+## Allowlist
+
+Skills that invoke scripts need `Bash` in their `allowed-tools`. Adding `Bash` is the responsibility of the SKILL.md edit that introduces the script call, not a separate preparatory step. Do not broaden `allowed-tools` beyond `Bash` for offloading.
+
+## Non-scope
+
+The non-offloadable surface defined in spec §1.4 — library matching, adversarial reasoning, classification, finding interpretation, semantic grouping — stays in the skill body. Scripts are for deterministic work only.

--- a/plugins/triage/skills/triage/references/triage-schema.md
+++ b/plugins/triage/skills/triage/references/triage-schema.md
@@ -1,0 +1,66 @@
+# Triage Record Schema
+
+One YAML file per triaged task, stored at `.claude/triage/<slug>.yaml` (project scope) or the user-global fallback resolved by `resolve-triage-path.sh`.
+
+## Filename
+
+- **Slug**: lowercase, hyphen-separated, derived from the task description. Max 50 chars.
+  - Example: task `"Add SSO login for admin users"` → slug `add-sso-login-for-admin-users`.
+- **Draft suffix**: while the record is unconfirmed, the file is `<slug>.draft.yaml`. On confirmation, the skill renames it to `<slug>.yaml`. Draft files should be ignored by CI and are fine to `.gitignore` (`.claude/triage/*.draft.yaml`).
+- **Collision**: if `<slug>.yaml` already exists for an unrelated task, append `-2`, `-3`, etc.
+
+## Schema
+
+```yaml
+task: "<full task description as the user phrased it>"
+created: "<ISO-8601 date, e.g. 2026-04-23>"
+classification: "<UI Feature|Logic Feature|Mixed Feature|Bug Fix|Refactor|Design|Review|Other>"
+confidence: "<High|Medium|Low>"
+status: "<draft|in_progress|complete|abandoned>"
+abstract_flow: ["Exploration", "Planning", "Implementation", "Review"]
+phases:
+  - phase: "Exploration"
+    skill: "<mapped-skill-name>"             # or "(generic prompt)" if no skill matched
+    alternative: null                        # or a second skill for tie-breakers
+    scope: "<1-sentence description of what this phase should accomplish for this task>"
+    status: "<pending|complete|skipped>"
+  - phase: "Planning"
+    skill: "<mapped-skill-name>"
+    alternative: "<alternative-skill-name>"  # only when Phase 4 left two plausible skills
+    scope: "..."
+    status: "pending"
+  # ...
+supporting_skills:                           # optional; tool-shaped skills that augment any phase
+  - skill: "<mapped-skill-name>"
+    when: "<one-sentence trigger condition for this task — when in the flow it would fire>"
+notes:                                       # optional free-form
+  - "<any flags from classification, e.g. 'touches mobile-framework prefixes'>"
+  - "<open spec references, e.g. 'specs/sso-login.md'>"
+```
+
+## Field semantics
+
+- **`status`** (top-level): lifecycle of the whole triage record.
+  - `draft` — written at Phase 6, not yet confirmed by user. File is `<slug>.draft.yaml`.
+  - `in_progress` — user confirmed; work is underway. File is `<slug>.yaml`.
+  - `complete` — all phases complete, or user marked the whole task done.
+  - `abandoned` — user explicitly abandoned; preserved for history but excluded from `--active`.
+- **`phases[].status`**:
+  - `pending` — not started.
+  - `complete` — finished (user confirmed or the skill marked it on re-invocation).
+  - `skipped` — intentionally bypassed (e.g., Exploration on a trivial scope).
+- **`alternative`**: populated only when Phase 4's tie-breaker left two plausible skills for the same phase. The triage output surfaces it as `_Alternative: X — use if Y_`.
+- **`supporting_skills`**: tool-shaped skills (code-structure search, library-docs lookup, cross-session memory recall) that augment any phase rather than owning one. Populated by Phase 4's second pass. Omitted entirely if no tool-shaped skill matched. `when` is a per-task trigger condition, not the skill's generic description.
+
+## Invariants
+
+- `abstract_flow` length == `phases` length; entries align by index.
+- `phases[].phase` matches the string in `abstract_flow` at the same index.
+- A record with top-level `status: draft` is never read by `--active` unless `draft` is explicitly requested (the recall script's `--active` mode includes drafts by design — they represent unfinished planning the next session should resume).
+- Records are **append-only** in the git sense: once `in_progress`, don't rewrite `task`/`classification`/`created`. Only `status`, `phases[].status`, and `notes` may change.
+
+## Why YAML and not Markdown
+
+- Structured fields (status, per-phase state) are checked by scripts — YAML gives a clean contract.
+- Still human-readable and diffable in PR review.
+- One file per task means status updates produce small, isolated diffs; no churn from unrelated triages.

--- a/plugins/triage/skills/triage/scripts/discover-skills.mjs
+++ b/plugins/triage/skills/triage/scripts/discover-skills.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+// Serves: triage SKILL.md — Phase 1 Context & Config Discovery (§1.2.12)
+//
+// Walk six globs across three scopes (project-local, user-global,
+// plugin-installed), extract `name` + `description` from each file's YAML
+// frontmatter, and emit a JSON array on stdout. Skill body consumes the
+// JSON to build Phase 4's candidate list — the model no longer globs or
+// parses frontmatter itself.
+//
+// Usage: discover-skills.mjs <project-root> <home-dir>
+//
+// Both arguments must be absolute paths. `home-dir` is passed explicitly
+// (rather than read from $HOME) to honour the contract's no-env rule
+// (~/.claude/skills/_conventions/offload-scripts.md §Inputs).
+//
+// Exit 0 + JSON on stdout on success. Exit non-zero + one-line stderr
+// diagnostic on: bad argv, unreadable file, missing or malformed
+// frontmatter, or frontmatter missing required `name` / `description`.
+//
+// Missing directories (e.g. project has no .claude/) are NOT failures — the
+// corresponding scope contributes zero records. Empty `_conventions/` and
+// other workspace dirs lacking a SKILL.md are silently skipped.
+//
+// Dependencies: node >= 18. No external tools.
+//
+// Output shape (array; may be empty):
+//   [
+//     { "scope": "project-local" | "user-global" | "plugin-installed",
+//       "kind":  "skill" | "agent" | "mcp-server",
+//       "name":  "...",
+//       "description": "...",
+//       "path":  "..." }
+//   ]
+//
+// Note on shape vs spec §1.2.12: spec example omits `kind`. Triage Phase 1
+// builds a unified candidate list mixing skills and agents, and Phase 4
+// maps both — emitting `kind` here prevents the skill body from re-deriving
+// it from the path, which would defeat the offload.
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+function die(msg, code = 1) {
+  process.stderr.write(`discover-skills: ${msg}\n`);
+  process.exit(code);
+}
+
+function requireAbsolute(p, label) {
+  if (!isAbsolute(p)) die(`${label} must be an absolute path: ${p}`, 2);
+}
+
+function listSubdirs(parent) {
+  if (!existsSync(parent)) return [];
+  try {
+    if (!statSync(parent).isDirectory()) return [];
+    return readdirSync(parent, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => join(parent, e.name))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function listMdFiles(parent) {
+  if (!existsSync(parent)) return [];
+  try {
+    if (!statSync(parent).isDirectory()) return [];
+    return readdirSync(parent, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith(".md"))
+      .map((e) => join(parent, e.name))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+function skillFilesIn(skillsDir) {
+  return listSubdirs(skillsDir)
+    .map((d) => join(d, "SKILL.md"))
+    .filter((p) => existsSync(p) && statSync(p).isFile());
+}
+
+// Walk a plugin root tolerantly: any dir at depth 1-4 containing a `skills/`
+// or `agents/` subdir is treated as a plugin version root. Handles both
+// Claude Code's canonical `<cache>/<org>/<pkg>/<ver>/skills/` layout and
+// flatter alternates (`<plugins>/<pkg>/skills/`, `<plugins>/<pkg>/<ver>/skills/`).
+// Bounded depth prevents pathological traversal of unrelated trees.
+function walkPluginRoots(root, maxDepth = 4) {
+  const skillsDirs = [];
+  const agentsDirs = [];
+  function recurse(dir, depth) {
+    if (depth > maxDepth) return;
+    const skillsSub = join(dir, "skills");
+    const agentsSub = join(dir, "agents");
+    if (existsSync(skillsSub) && statSync(skillsSub).isDirectory()) skillsDirs.push(skillsSub);
+    if (existsSync(agentsSub) && statSync(agentsSub).isDirectory()) agentsDirs.push(agentsSub);
+    for (const sub of listSubdirs(dir)) {
+      const base = sub.split("/").pop();
+      if (base === "skills" || base === "agents") continue; // already handled above
+      recurse(sub, depth + 1);
+    }
+  }
+  recurse(root, 0);
+  return { skillsDirs, agentsDirs };
+}
+
+function pluginSkillFiles(pluginsDir) {
+  const { skillsDirs } = walkPluginRoots(pluginsDir);
+  const out = [];
+  for (const d of skillsDirs) out.push(...skillFilesIn(d));
+  return out;
+}
+
+function pluginAgentFiles(pluginsDir) {
+  const { agentsDirs } = walkPluginRoots(pluginsDir);
+  const out = [];
+  for (const d of agentsDirs) out.push(...listMdFiles(d));
+  return out;
+}
+
+function extractFrontmatter(path) {
+  let content;
+  try {
+    content = readFileSync(path, "utf8");
+  } catch (e) {
+    die(`cannot read ${path}: ${e.message}`);
+  }
+  const m = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+  if (!m) die(`no YAML frontmatter in ${path}`);
+  return m[1];
+}
+
+// Minimal top-level scalar parser — extracts `name` and `description` only.
+// Triage doesn't need nested frontmatter (allowed-tools arrays, etc.), and
+// these two fields are always string scalars on any well-formed SKILL.md.
+// Handles: plain, 'single-quoted', "double-quoted", and folded/block scalars
+// that continue onto indented lines until the next top-level key or EOF.
+function parseYamlFallback(block) {
+  const lines = block.split(/\r?\n/);
+  const result = {};
+  let currentKey = null;
+  let blockBuf = [];
+  let blockMode = null; // '|' literal, '>' folded, or null (plain continuation)
+
+  const flushBlock = () => {
+    if (currentKey && blockBuf.length > 0) {
+      const joined = blockMode === ">"
+        ? blockBuf.join(" ").replace(/\s+/g, " ").trim()
+        : blockBuf.join("\n").trimEnd();
+      result[currentKey] = (result[currentKey] || "") + joined;
+    }
+    currentKey = null;
+    blockBuf = [];
+    blockMode = null;
+  };
+
+  const unquote = (s) => {
+    s = s.trim();
+    if (s.length >= 2) {
+      const q = s[0];
+      if ((q === '"' || q === "'") && s.endsWith(q)) {
+        return s.slice(1, -1).replace(/\\"/g, '"').replace(/\\'/g, "'");
+      }
+    }
+    return s;
+  };
+
+  for (const raw of lines) {
+    // Top-level key line: `key: value` or `key:` or `key: |` / `key: >`
+    const m = raw.match(/^([A-Za-z_][\w-]*)\s*:\s*(.*)$/);
+    if (m && !raw.startsWith(" ") && !raw.startsWith("\t")) {
+      flushBlock();
+      const [, key, rest] = m;
+      if (rest === "|" || rest === ">") {
+        currentKey = key;
+        blockMode = rest;
+      } else if (rest === "") {
+        // Either a mapping/list follows (ignored) or a continuation block.
+        currentKey = key;
+        blockMode = null;
+      } else {
+        result[key] = unquote(rest);
+      }
+    } else if (currentKey && /^\s+/.test(raw)) {
+      blockBuf.push(raw.replace(/^\s+/, ""));
+    } else if (raw.trim() === "") {
+      if (blockMode === ">") blockBuf.push("");
+    } else {
+      flushBlock();
+    }
+  }
+  flushBlock();
+  return result;
+}
+
+// yq removed for cross-platform portability: triage only needs the top-level
+// `name` and `description` scalars, which parseYamlFallback handles for plain,
+// quoted, and block-scalar forms. No external YAML tool is required.
+function parseYaml(block /*, path */) {
+  return parseYamlFallback(block);
+}
+
+function recordFrom(path, scope, kind) {
+  const fm = parseYaml(extractFrontmatter(path), path);
+  if (!fm || typeof fm !== "object" || Array.isArray(fm)) {
+    die(`frontmatter is not a mapping in ${path}`);
+  }
+  const { name, description } = fm;
+  if (typeof name !== "string" || name.length === 0) {
+    die(`missing or non-string \`name\` in frontmatter: ${path}`);
+  }
+  if (typeof description !== "string" || description.length === 0) {
+    die(`missing or non-string \`description\` in frontmatter: ${path}`);
+  }
+  return { scope, kind, name, description, path };
+}
+
+function readJsonSafe(file) {
+  try { return JSON.parse(readFileSync(file, "utf8")); } catch { return null; }
+}
+
+// Accepts either the wrapped form ({ mcpServers: { name: cfg } }) used by
+// project .mcp.json and ~/.claude.json, or the bare map ({ name: cfg }) used
+// by plugin .mcp.json files. Returns the name->config object, or {}.
+function serverMapOf(parsed) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  if (parsed.mcpServers && typeof parsed.mcpServers === "object" && !Array.isArray(parsed.mcpServers)) {
+    return parsed.mcpServers;
+  }
+  return parsed;
+}
+
+function mcpRecordsFrom(parsed, scope, path) {
+  const out = [];
+  for (const [name, cfg] of Object.entries(serverMapOf(parsed))) {
+    if (!cfg || typeof cfg !== "object") continue;
+    const description = typeof cfg.description === "string" ? cfg.description : "";
+    out.push({ scope, kind: "mcp-server", name, description, path });
+  }
+  return out;
+}
+
+// Find plugin-shipped .mcp.json files within the plugins dir (bounded depth).
+function findPluginMcpFiles(root, maxDepth = 6) {
+  const found = [];
+  if (!existsSync(root)) return found;
+  (function recurse(dir, depth) {
+    if (depth > maxDepth) return;
+    let entries;
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = join(dir, e.name);
+      if (e.isFile() && e.name === ".mcp.json") found.push(full);
+      else if (e.isDirectory()) recurse(full, depth + 1);
+    }
+  })(root, 0);
+  return found;
+}
+
+function discoverMcp(projectRoot, homeDir) {
+  const out = [];
+  // 1. Project-level .mcp.json (wrapped form).
+  const projMcp = join(projectRoot, ".mcp.json");
+  if (existsSync(projMcp)) out.push(...mcpRecordsFrom(readJsonSafe(projMcp), "project-local", projMcp));
+  // 2. User-level ~/.claude.json: global + this project's per-project entry.
+  const userCfg = join(homeDir, ".claude.json");
+  if (existsSync(userCfg)) {
+    const j = readJsonSafe(userCfg);
+    if (j) {
+      if (j.mcpServers) out.push(...mcpRecordsFrom({ mcpServers: j.mcpServers }, "user-global", userCfg));
+      const proj = j.projects && j.projects[projectRoot];
+      if (proj && proj.mcpServers) out.push(...mcpRecordsFrom({ mcpServers: proj.mcpServers }, "user-global", userCfg));
+    }
+  }
+  // 3. Plugin-shipped .mcp.json (bare map form).
+  for (const f of findPluginMcpFiles(join(homeDir, ".claude", "plugins"))) {
+    out.push(...mcpRecordsFrom(readJsonSafe(f), "plugin-installed", f));
+  }
+  // Dedupe by scope+name (a server can legitimately appear in more than one source).
+  const seen = new Set();
+  return out.filter((r) => {
+    const k = `${r.scope}::${r.name}`;
+    return seen.has(k) ? false : (seen.add(k), true);
+  });
+}
+
+function main() {
+  const [projectRoot, homeDir] = process.argv.slice(2);
+  if (!projectRoot || !homeDir) {
+    die("usage: discover-skills.mjs <project-root> <home-dir>", 2);
+  }
+  requireAbsolute(projectRoot, "project-root");
+  requireAbsolute(homeDir, "home-dir");
+
+  const out = [];
+
+  for (const p of skillFilesIn(join(projectRoot, ".claude", "skills"))) {
+    out.push(recordFrom(p, "project-local", "skill"));
+  }
+  for (const p of listMdFiles(join(projectRoot, ".claude", "agents"))) {
+    out.push(recordFrom(p, "project-local", "agent"));
+  }
+
+  for (const p of skillFilesIn(join(homeDir, ".claude", "skills"))) {
+    out.push(recordFrom(p, "user-global", "skill"));
+  }
+  for (const p of listMdFiles(join(homeDir, ".claude", "agents"))) {
+    out.push(recordFrom(p, "user-global", "agent"));
+  }
+
+  // Plugin root is `<home>/.claude/plugins/`, not just `/cache/`. The
+  // tolerant walker finds any `skills/` or `agents/` subdir within depth 4,
+  // covering the canonical `cache/<org>/<pkg>/<ver>/` layout plus any
+  // flatter alternates (e.g. `installed/<pkg>/`, user-symlinked plugins).
+  const pluginsDir = join(homeDir, ".claude", "plugins");
+  const seen = new Set();
+  const uniq = (p) => (seen.has(p) ? false : (seen.add(p), true));
+  for (const p of pluginSkillFiles(pluginsDir)) {
+    if (uniq(p)) out.push(recordFrom(p, "plugin-installed", "skill"));
+  }
+  for (const p of pluginAgentFiles(pluginsDir)) {
+    if (uniq(p)) out.push(recordFrom(p, "plugin-installed", "agent"));
+  }
+
+  out.push(...discoverMcp(projectRoot, homeDir));
+
+  process.stdout.write(JSON.stringify(out) + "\n");
+}
+
+main();

--- a/plugins/triage/skills/triage/scripts/find-open-specs.mjs
+++ b/plugins/triage/skills/triage/scripts/find-open-specs.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Serves: triage SKILL.md — open-specs scan (Phase 1c).
+// Inputs (argv): --root <abs>
+// stdout: JSON array of { "slug": "<basename-minus-md>", "path": "<abs>" }, recursive under <root>/specs, sorted by path.
+// Missing specs/ -> []. Exit 2 + stderr on missing/relative/non-dir --root.
+import { statSync, readdirSync } from "node:fs";
+import { isAbsolute, join, basename } from "node:path";
+
+function die(msg) { process.stderr.write(`find-open-specs: ${msg}\n`); process.exit(2); }
+function isDir(p) { try { return statSync(p).isDirectory(); } catch { return false; } }
+
+const argv = process.argv.slice(2);
+let root = "";
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--root") { if (i + 1 >= argv.length) die("--root requires a value"); root = argv[++i]; }
+  else die(`unknown arg: ${a}`);
+}
+if (!root) die("--root is required");
+if (!isAbsolute(root)) die(`--root must be absolute: ${root}`);
+if (!isDir(root)) die(`root is not a directory: ${root}`);
+
+const specsDir = join(root, "specs");
+if (!isDir(specsDir)) { process.stdout.write("[]\n"); process.exit(0); }
+
+const files = [];
+(function walk(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) walk(full);
+    else if (e.isFile() && e.name.endsWith(".md")) files.push(full);
+  }
+})(specsDir);
+
+files.sort();
+const out = files.map((f) => ({ slug: basename(f).replace(/\.md$/, ""), path: f }));
+process.stdout.write(`${JSON.stringify(out)}\n`);

--- a/plugins/triage/skills/triage/scripts/resolve-triage-path.mjs
+++ b/plugins/triage/skills/triage/scripts/resolve-triage-path.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Serves: triage SKILL.md — storage path detection (Phase 6, Phase 1a active check).
+// Inputs (argv): --root <abs> --home <abs> [--path-only]
+// stdout (default): {"path":"<abs>","scope":"project"|"user"} | {"path":null,"scope":null}
+// stdout (--path-only): the resolved path, or an empty line if null (replaces the old python3 pluck).
+// Precedence: <root>/.claude/triage/  >  <root>/.claude/ exists  >  <home>/.claude/projects/<slug>/triage/  >  null.
+// slug = <root> with '/' -> '-'. Exit 0 on success; exit 2 + stderr on bad argv.
+import { statSync } from "node:fs";
+import { isAbsolute, join } from "node:path";
+
+function die(msg) { process.stderr.write(`resolve-triage-path: ${msg}\n`); process.exit(2); }
+function isDir(p) { try { return statSync(p).isDirectory(); } catch { return false; } }
+
+const argv = process.argv.slice(2);
+let root = "", home = "", pathOnly = false;
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--root") { if (i + 1 >= argv.length) die("--root requires a value"); root = argv[++i]; }
+  else if (a === "--home") { if (i + 1 >= argv.length) die("--home requires a value"); home = argv[++i]; }
+  else if (a === "--path-only") { pathOnly = true; }
+  else die(`unknown arg: ${a}`);
+}
+if (!root) die("--root is required");
+if (!home) die("--home is required");
+if (!isAbsolute(root)) die(`--root must be absolute: ${root}`);
+if (!isAbsolute(home)) die(`--home must be absolute: ${home}`);
+
+const projectTriage = join(root, ".claude", "triage");
+let result;
+if (isDir(projectTriage)) result = { path: projectTriage, scope: "project" };
+else if (isDir(join(root, ".claude"))) result = { path: projectTriage, scope: "project" };
+else {
+  const slug = root.replaceAll("/", "-");
+  const userTriage = join(home, ".claude", "projects", slug, "triage");
+  result = isDir(userTriage) ? { path: userTriage, scope: "user" } : { path: null, scope: null };
+}
+
+process.stdout.write(pathOnly ? `${result.path ?? ""}\n` : `${JSON.stringify(result)}\n`);

--- a/plugins/triage/skills/triage/scripts/triage-recall.mjs
+++ b/plugins/triage/skills/triage/scripts/triage-recall.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Serves: triage SKILL.md — cross-session retrieval of triage records.
+// The single read path for <dir>/*.yaml (SKILL.md forbids inline globbing).
+// Inputs (argv):
+//   --dir <abs>       required — triage dir (from resolve-triage-path).
+//   --active          list records with status in {draft, in_progress}.
+//   --find <query>    case-insensitive substring match on the task field.
+//   --show <slug>     emit one record (slug = filename minus .yaml / .draft.yaml).
+//   --json            machine-readable JSON (default: human-readable).
+// Exactly one of --active|--find|--show. Exit 0 even when empty; exit 2 + stderr on bad argv.
+import { statSync, readdirSync, readFileSync } from "node:fs";
+import { isAbsolute, join, basename } from "node:path";
+
+function die(msg) { process.stderr.write(`triage-recall: ${msg}\n`); process.exit(2); }
+function isDir(p) { try { return statSync(p).isDirectory(); } catch { return false; } }
+function isFile(p) { try { return statSync(p).isFile(); } catch { return false; } }
+
+const argv = process.argv.slice(2);
+let dir = "", mode = "", query = "", slug = "", json = false;
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--dir") { if (i + 1 >= argv.length) die("--dir requires value"); dir = argv[++i]; }
+  else if (a === "--active") { mode = "active"; }
+  else if (a === "--find") { mode = "find"; if (i + 1 >= argv.length) die("--find requires query"); query = argv[++i]; }
+  else if (a === "--show") { mode = "show"; if (i + 1 >= argv.length) die("--show requires slug"); slug = argv[++i]; }
+  else if (a === "--json") { json = true; }
+  else die(`unknown arg: ${a}`);
+}
+if (!dir) die("--dir is required");
+if (!mode) die("one of --active|--find|--show is required");
+if (!isAbsolute(dir)) die(`--dir must be absolute: ${dir}`);
+
+if (!isDir(dir)) { process.stdout.write(json ? "[]\n" : "(no triage records)\n"); process.exit(0); }
+
+// Extract a single top-level scalar `^field: value`; strip a leading and a trailing quote
+// independently (mirrors the original awk gsub behavior). Returns "" when absent.
+function yamlField(content, field) {
+  const esc = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = content.match(new RegExp(`^${esc}:[ \\t]*(.*)$`, "m"));
+  if (!m) return "";
+  return m[1].replace(/^["']/, "").replace(/["']$/, "");
+}
+
+function baseSlug(file) {
+  return basename(file).replace(/\.yaml$/, "").replace(/\.draft$/, "");
+}
+
+function listYaml() {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".yaml"))
+    .map((e) => join(dir, e.name))
+    .sort();
+}
+
+function record(file) {
+  const c = readFileSync(file, "utf8");
+  return {
+    slug: baseSlug(file),
+    status: yamlField(c, "status"),
+    task: yamlField(c, "task"),
+    created: yamlField(c, "created"),
+    classification: yamlField(c, "classification"),
+    path: file,
+  };
+}
+
+let matches = [];
+if (mode === "active") {
+  matches = listYaml().filter((f) => {
+    const s = yamlField(readFileSync(f, "utf8"), "status");
+    return s === "draft" || s === "in_progress";
+  });
+} else if (mode === "find") {
+  const needle = query.toLowerCase();
+  matches = listYaml().filter((f) => yamlField(readFileSync(f, "utf8"), "task").toLowerCase().includes(needle));
+} else if (mode === "show") {
+  for (const cand of [join(dir, `${slug}.yaml`), join(dir, `${slug}.draft.yaml`)]) {
+    if (isFile(cand)) matches.push(cand);
+  }
+}
+
+if (matches.length === 0) {
+  process.stdout.write(json ? "[]\n" : "(no matching triage records)\n");
+  process.exit(0);
+}
+
+if (json) {
+  process.stdout.write(`${JSON.stringify(matches.map(record))}\n`);
+} else if (mode === "show") {
+  const f = matches[0];
+  process.stdout.write(`# ${f}\n${readFileSync(f, "utf8")}`);
+} else {
+  let out = "";
+  for (const f of matches) {
+    const r = record(f);
+    out += `${r.slug}  [${r.status}]  ${r.task}\n`;
+    if (r.created) out += `  created: ${r.created}\n`;
+    if (r.classification) out += `  classification: ${r.classification}\n`;
+    out += `  path: ${f}\n\n`;
+  }
+  process.stdout.write(out);
+}

--- a/plugins/triage/test/discover-skills.test.mjs
+++ b/plugins/triage/test/discover-skills.test.mjs
@@ -1,0 +1,71 @@
+// test/discover-skills.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage/scripts/discover-skills.mjs", import.meta.url));
+const run = (root, home) => JSON.parse(execFileSync("node", [SCRIPT, root, home], { encoding: "utf8" }));
+
+function mkSkill(dir, name, desc) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `---\nname: ${name}\ndescription: ${desc}\n---\n# ${name}\n`);
+}
+
+test("still discovers skills with yq absent (inline parser)", () => {
+  const root = mkdtempSync(join(tmpdir(), "ds-root-"));
+  const home = mkdtempSync(join(tmpdir(), "ds-home-"));
+  mkSkill(join(root, ".claude", "skills", "foo"), "foo", "does foo things");
+  const out = run(root, home);
+  const foo = out.find((r) => r.name === "foo");
+  assert.ok(foo, "foo skill discovered");
+  assert.equal(foo.kind, "skill");
+  assert.equal(foo.scope, "project-local");
+});
+
+test("discovers MCP servers from project .mcp.json (wrapped form)", () => {
+  const root = mkdtempSync(join(tmpdir(), "ds-root-"));
+  const home = mkdtempSync(join(tmpdir(), "ds-home-"));
+  writeFileSync(join(root, ".mcp.json"),
+    JSON.stringify({ mcpServers: { serena: { command: "serena", description: "semantic code tools" } } }));
+  const out = run(root, home);
+  const m = out.find((r) => r.kind === "mcp-server" && r.name === "serena");
+  assert.ok(m, "serena MCP discovered");
+  assert.equal(m.scope, "project-local");
+  assert.equal(m.description, "semantic code tools");
+});
+
+test("discovers MCP servers from ~/.claude.json per-project entry", () => {
+  const root = mkdtempSync(join(tmpdir(), "ds-root-"));
+  const home = mkdtempSync(join(tmpdir(), "ds-home-"));
+  writeFileSync(join(home, ".claude.json"),
+    JSON.stringify({ mcpServers: {}, projects: { [root]: { mcpServers: { angular: { command: "ng-mcp" } } } } }));
+  const out = run(root, home);
+  const m = out.find((r) => r.kind === "mcp-server" && r.name === "angular");
+  assert.ok(m, "angular MCP discovered from per-project entry");
+  assert.equal(m.scope, "user-global");
+  assert.equal(m.description, "");           // no description in config -> empty string
+});
+
+test("discovers MCP servers from plugin .mcp.json (bare map form)", () => {
+  const root = mkdtempSync(join(tmpdir(), "ds-root-"));
+  const home = mkdtempSync(join(tmpdir(), "ds-home-"));
+  const pdir = join(home, ".claude", "plugins", "cache", "acme", "code-review-graph", "1.0.0");
+  mkdirSync(pdir, { recursive: true });
+  writeFileSync(join(pdir, ".mcp.json"),
+    JSON.stringify({ "code-review-graph": { command: "crg", description: "graph-based code review" } }));
+  const out = run(root, home);
+  const m = out.find((r) => r.kind === "mcp-server" && r.name === "code-review-graph");
+  assert.ok(m, "plugin MCP server discovered (bare map)");
+  assert.equal(m.scope, "plugin-installed");
+});
+
+test("zero MCP config -> no mcp-server records, no error", () => {
+  const root = mkdtempSync(join(tmpdir(), "ds-root-"));
+  const home = mkdtempSync(join(tmpdir(), "ds-home-"));
+  const out = run(root, home);
+  assert.equal(out.filter((r) => r.kind === "mcp-server").length, 0);
+});

--- a/plugins/triage/test/find-open-specs.test.mjs
+++ b/plugins/triage/test/find-open-specs.test.mjs
@@ -1,0 +1,41 @@
+// test/find-open-specs.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage/scripts/find-open-specs.mjs", import.meta.url));
+const run = (args) => execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" });
+const runFail = (args) => {
+  try { execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }); return null; }
+  catch (e) { return { status: e.status, stderr: e.stderr }; }
+};
+
+test("no specs dir -> empty array", () => {
+  const root = mkdtempSync(join(tmpdir(), "fos-"));
+  assert.deepEqual(JSON.parse(run(["--root", root])), []);
+});
+
+test("finds .md recursively, sorted by path, slug is basename minus .md", () => {
+  const root = mkdtempSync(join(tmpdir(), "fos-"));
+  mkdirSync(join(root, "specs", "sub"), { recursive: true });
+  writeFileSync(join(root, "specs", "b-feature.md"), "x");
+  writeFileSync(join(root, "specs", "a-feature.md"), "x");
+  writeFileSync(join(root, "specs", "sub", "c-feature.md"), "x");
+  writeFileSync(join(root, "specs", "ignore.txt"), "x");
+  const out = JSON.parse(run(["--root", root]));
+  assert.deepEqual(out, [
+    { slug: "a-feature", path: join(root, "specs", "a-feature.md") },
+    { slug: "b-feature", path: join(root, "specs", "b-feature.md") },
+    { slug: "c-feature", path: join(root, "specs", "sub", "c-feature.md") },
+  ]);
+});
+
+test("relative root exits 2", () => {
+  const r = runFail(["--root", "rel"]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /must be absolute/);
+});

--- a/plugins/triage/test/resolve-triage-path.test.mjs
+++ b/plugins/triage/test/resolve-triage-path.test.mjs
@@ -1,0 +1,71 @@
+// test/resolve-triage-path.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage/scripts/resolve-triage-path.mjs", import.meta.url));
+const run = (args) => execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" });
+const runFail = (args) => {
+  try { execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }); return null; }
+  catch (e) { return { status: e.status, stderr: e.stderr }; }
+};
+
+test("project triage dir present -> scope project", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  mkdirSync(join(root, ".claude", "triage"), { recursive: true });
+  const out = JSON.parse(run(["--root", root, "--home", "/home/x"]));
+  assert.deepEqual(out, { path: join(root, ".claude", "triage"), scope: "project" });
+});
+
+test(".claude present but no triage dir -> scope project, path still triage", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  mkdirSync(join(root, ".claude"), { recursive: true });
+  const out = JSON.parse(run(["--root", root, "--home", "/home/x"]));
+  assert.deepEqual(out, { path: join(root, ".claude", "triage"), scope: "project" });
+});
+
+test("no .claude, existing user-global triage -> scope user", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  const home = mkdtempSync(join(tmpdir(), "home-"));
+  const slug = root.replaceAll("/", "-");
+  mkdirSync(join(home, ".claude", "projects", slug, "triage"), { recursive: true });
+  const out = JSON.parse(run(["--root", root, "--home", home]));
+  assert.deepEqual(out, { path: join(home, ".claude", "projects", slug, "triage"), scope: "user" });
+});
+
+test("nothing configured -> null/null", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  const home = mkdtempSync(join(tmpdir(), "home-"));
+  const out = JSON.parse(run(["--root", root, "--home", home]));
+  assert.deepEqual(out, { path: null, scope: null });
+});
+
+test("--path-only emits bare path", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  mkdirSync(join(root, ".claude", "triage"), { recursive: true });
+  const out = run(["--root", root, "--home", "/home/x", "--path-only"]).trim();
+  assert.equal(out, join(root, ".claude", "triage"));
+});
+
+test("--path-only on null emits empty line", () => {
+  const root = mkdtempSync(join(tmpdir(), "tr-"));
+  const home = mkdtempSync(join(tmpdir(), "home-"));
+  const out = run(["--root", root, "--home", home, "--path-only"]);
+  assert.equal(out, "\n");
+});
+
+test("relative --root exits 2", () => {
+  const r = runFail(["--root", "rel/path", "--home", "/home/x"]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /must be absolute/);
+});
+
+test("missing --home exits 2", () => {
+  const r = runFail(["--root", "/abs"]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /--home is required/);
+});

--- a/plugins/triage/test/triage-recall.test.mjs
+++ b/plugins/triage/test/triage-recall.test.mjs
@@ -1,0 +1,79 @@
+// test/triage-recall.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage/scripts/triage-recall.mjs", import.meta.url));
+const run = (args) => execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" });
+const runFail = (args) => {
+  try { execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }); return null; }
+  catch (e) { return { status: e.status, stderr: e.stderr }; }
+};
+
+function seed() {
+  const dir = mkdtempSync(join(tmpdir(), "tri-"));
+  writeFileSync(join(dir, "add-auth.yaml"),
+    'task: "Add SSO login"\nstatus: in_progress\ncreated: 2026-06-01\nclassification: Logic Feature\n');
+  writeFileSync(join(dir, "fix-bug.draft.yaml"),
+    "task: Fix flaky test\nstatus: draft\ncreated: 2026-06-02\nclassification: Bug Fix\n");
+  writeFileSync(join(dir, "done-thing.yaml"),
+    "task: Old thing\nstatus: resolved\ncreated: 2026-05-01\nclassification: Refactor\n");
+  return dir;
+}
+
+test("--active --json lists draft + in_progress, sorted by filename", () => {
+  const dir = seed();
+  const out = JSON.parse(run(["--dir", dir, "--active", "--json"]));
+  assert.deepEqual(out.map((r) => r.slug), ["add-auth", "fix-bug"]);
+  assert.equal(out[0].status, "in_progress");
+  assert.equal(out[0].task, "Add SSO login");      // double-quotes stripped
+  assert.equal(out[1].slug, "fix-bug");             // .draft suffix stripped
+  assert.equal(out[1].status, "draft");
+});
+
+test("--find is case-insensitive substring on task", () => {
+  const dir = seed();
+  const out = JSON.parse(run(["--dir", dir, "--find", "SSO", "--json"]));
+  assert.deepEqual(out.map((r) => r.slug), ["add-auth"]);
+});
+
+test("--show emits full YAML body with leading # path", () => {
+  const dir = seed();
+  const out = run(["--dir", dir, "--show", "add-auth"]);
+  assert.match(out, new RegExp(`^# ${dir.replaceAll("\\\\", "\\\\\\\\")}.*add-auth\\.yaml\\n`));
+  assert.match(out, /task: "Add SSO login"/);
+});
+
+test("--show falls back to .draft.yaml", () => {
+  const dir = seed();
+  const out = run(["--dir", dir, "--show", "fix-bug"]);
+  assert.match(out, /status: draft/);
+});
+
+test("missing dir -> empty json array, exit 0", () => {
+  const out = run(["--dir", "/no/such/dir/here", "--active", "--json"]);
+  assert.equal(out, "[]\n");
+});
+
+test("no matches -> empty json array", () => {
+  const dir = seed();
+  const out = run(["--dir", dir, "--find", "zzz-nomatch", "--json"]);
+  assert.equal(out, "[]\n");
+});
+
+test("no mode -> exit 2", () => {
+  const dir = seed();
+  const r = runFail(["--dir", dir]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /one of --active\|--find\|--show/);
+});
+
+test("relative --dir -> exit 2", () => {
+  const r = runFail(["--dir", "rel", "--active"]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /must be absolute/);
+});


### PR DESCRIPTION
## Summary

Folds the `/triage` advisory task classifier into claude-salad as a third plugin (`triage@mpiccinnonode`), ported from the standalone `claude-triage` repo. This consolidates all of mpiccinnonode's plugins under one marketplace so users add a single source.

## What's included

- `plugins/triage/` — self-contained plugin: SKILL.md (`${CLAUDE_PLUGIN_ROOT}` paths), 4 node-only helper scripts (`.mjs`), 2 references, README, CLAUDE.md.
- **MCP-server discovery** — `discover-skills.mjs` surfaces `kind: "mcp-server"` records from project `.mcp.json`, `~/.claude.json` per-project entry, and plugin `.mcp.json` (wrapped + bare-map forms).
- **Tests** — `node:test` parity + MCP fixture suite, **24 tests, zero deps**. Run: `cd plugins/triage && npm test`.
- `marketplace.json` — third plugin entry.
- `CLAUDE.md` — **lifts the pure-markdown-only rule** to allow minimal runtime scripts + dependency-free tests (triage is the first plugin with executable logic).

## Notes

- **Cross-platform / node-only**: no shell, jq, awk, sed, yq, or python — Windows-native.
- **Markdown lint**: triage adds **0** errors under CI's pinned `markdownlint-cli2@0.14.0`. ⚠️ The Markdown Lint check will still show red — that's a **pre-existing** baseline (~18 errors in config-doctor/scrum-toolkit) unrelated to this PR; the lint workflow has been failing on every run since before this branch.
- Planning spec/plan docs are intentionally **not** vendored (dev artifacts; they added 33 lint errors and aren't plugin runtime content).
- The standalone `claude-triage` repo will be retired only **after** triage reaches `main` via a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)