### PR TITLE
chore: sync main → develop after review-then-dry v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## review-then-dry 1.0.0 (new plugin)
+
+- feat(review-then-dry): scaffold Node-only, Windows-portable plugin (no shell/jq/yq/python)
+- feat(review-then-dry): add /review-then-dry orchestrator chaining lifecycled-code-review + dry into one unified findings spec
+- feat(review-then-dry): add lifecycled-code-review skill (renamed from built-in code-review to avoid collision) and dry reuse-audit skill
+- feat(review-then-dry): port five helper scripts from POSIX shell to Node — get-review-targets, safe-write-yaml, get-spec-context, evict-staged, lifecycle-pass
+- feat(review-then-dry): vendor js-yaml v4 ESM build (decided over npm dep) with a parity test; js-yaml kept as devDependency for CVE hygiene only
+- feat(review-then-dry): add cold-start checklist gate and spec-path prompts
+- test(review-then-dry): node:test suite covering all scripts plus vendor parity (zero external deps)
+- docs(review-then-dry): vendor offload-scripts convention doc; add to README and sync plugin versions
+- chore(review-then-dry): register plugin in marketplace; add package-lock.json for reproducible installs
+
 ## scrum-toolkit 2.1.0 → 2.2.0
 
 - feat(user-story-edit): add /user-story-edit skill for targeted, diff-based amendments to existing GitHub user story issues

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ claude
 ```bash
 /plugin install scrum-toolkit
 ```
+```bash
+/plugin install triage
+```
 
 ### 4. Restart Claude Code
 


### PR DESCRIPTION
Syncs the review-then-dry v1.0.0 release back into develop:

- CHANGELOG.md release section for review-then-dry 1.0.0
- the v1.0.0 release merge commit

No functional changes beyond what already shipped to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)