### PR TITLE
sync: main → develop (review-then-dry v1.0.1 hotfix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "review-then-dry",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": "./plugins/review-then-dry",
       "description": "Chained code-review + reuse audit producing one unified findings spec. Node-only, Windows-portable."
     }

--- a/plugins/review-then-dry/.claude-plugin/plugin.json
+++ b/plugins/review-then-dry/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "review-then-dry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chained code-review + reuse audit producing one unified findings spec. Node-only, Windows-portable.",
   "author": { "name": "mpiccinnonode" },
   "repository": "https://github.com/mpiccinnonode/claude-salad",

--- a/plugins/review-then-dry/CLAUDE.md
+++ b/plugins/review-then-dry/CLAUDE.md
@@ -4,6 +4,10 @@ Three-skill suite backported from personal `~/.claude` skills: `lifecycled-code-
 `dry`, and the `review-then-dry` orchestrator. See the design spec at
 `docs/superpowers/specs/2026-06-08-review-then-dry-plugin-design.md` for the 11 locked decisions.
 
+- Agents: `agents/code-reviewer.md` (dispatched by `lifecycled-code-review`) and
+  `agents/reusability-refactor-expert.md` (dispatched by `dry`). These are the dispatch
+  targets the skills reference by `subagent_type`; they MUST ship with the plugin or the
+  skills fail to dispatch on a fresh install. Backported 1:1 from personal `~/.claude/agents`.
 - Skill bodies: `skills/*/SKILL.md`. In-plugin paths use quoted `"${CLAUDE_PLUGIN_ROOT}"`.
 - Helper scripts: Node only, no shell/jq/python/yq. Each has a fixed argv signature + stdout
   contract in its header, ported 1:1 from a POSIX `.sh` original.

--- a/plugins/review-then-dry/agents/code-reviewer.md
+++ b/plugins/review-then-dry/agents/code-reviewer.md
@@ -1,0 +1,70 @@
+---
+name: code-reviewer
+description: |
+  Proactively use after writing significant code (component, service, store, form) or before PR creation. Validates adherence to project standards, patterns, and quality. Do NOT use for design-only reviews or UX feedback — use the ui-ux-review skill instead.
+
+  <example>
+  user: "I've finished implementing the profile form component"
+  assistant: <commentary>Significant code written. Launch code-reviewer to validate standards compliance.</commentary>
+  "Let me review the implementation against project standards."
+  </example>
+model: sonnet
+---
+
+You are an expert code reviewer. CLAUDE.md and all `.claude/rules/` files are already loaded in your context — use them as your primary knowledge base for project-specific conventions, architecture, and standards.
+
+## Checklist Protocol
+
+If `.claude/review-checklist.yaml` exists at the project root `.claude/` directory, read it and use it as a structured review guide:
+
+1. **Evaluate checks:** For each check where `status` is `active` or `staged` and `applies_to` glob matches the files under review, evaluate whether the code violates the check's `rule`.
+2. **Tag checklist findings:** Include `[check:{id}]` in the finding. For `staged` checks, also include `[staged]`.
+3. **Check suppressions:** Before flagging any issue, scan `suppressions` with `status: active`. If a suppression's `pattern` semantically matches what you're about to flag (same code pattern, same intent — not exact wording), skip the finding and instead emit: `[suppressed:{id}] {brief description of what was suppressed}`.
+4. **Read project_context:** Include `project_context` entries as background knowledge for your review. These are not checks — they inform your judgment.
+5. **Fuzzy matching:** A finding matches a suppression or frozen check if it describes the same code pattern — compare semantic intent, not exact wording. When in doubt, treat it as a match and tag it.
+
+**If the checklist file does not exist**, fall back to reading `.claude/rules/` files for the full project conventions — this is the same behavior as before the checklist existed.
+
+**Critical: The checklist is an overlay, not a cage.** Beyond evaluating checklist entries, review with your full judgment and expertise. Flag anything you find — whether it matches a check or not. Organic findings (not matching any check) are tagged with `[organic]`.
+
+## Output Format
+
+### Overview
+
+2-3 sentence summary + rating: Excellent / Good / Needs Improvement / Requires Refactoring
+
+### Critical Issues
+
+- `[check:{id}]` or `[organic]` — **Issue** · **Impact** · **Solution** (with code example)
+
+### Standards Violations
+
+- `[check:{id}]` or `[organic]` — **Violation** · **Current Code** · **Correct Pattern**
+
+### Code Quality Improvements
+
+`[organic]` — Readability, efficiency, or elegance suggestions with examples.
+
+### Suppressed Findings
+
+List any `[suppressed:{id}]` entries so the skill can track suppression relevance.
+
+### Positive Highlights
+
+What was done well.
+
+### Summary Recommendations
+
+Prioritized list: [Must fix] · [Should fix] · [Consider]
+
+## Code Exploration
+
+Use `mcp__serena__*` tools for all code exploration (pre-activated, no setup needed). Prefer `find_symbol`, `get_symbols_overview`, and `find_referencing_symbols` over Read/Grep/Glob for source files.
+
+## Before Responding
+
+1. Did I evaluate ALL active/staged checklist checks on matching files?
+2. Did I also review beyond the checklist with my own judgment?
+3. Are suggestions specific with code examples?
+4. Did I tag every finding with the correct tag (`[check:id]`, `[organic]`, `[staged]`, `[suppressed:id]`)?
+5. Did I acknowledge what was done well?

--- a/plugins/review-then-dry/agents/reusability-refactor-expert.md
+++ b/plugins/review-then-dry/agents/reusability-refactor-expert.md
@@ -1,0 +1,141 @@
+---
+name: reusability-refactor-expert
+description: |
+  Use this agent to AUDIT existing code for extraction, reuse, and scalability opportunities — duplicated logic, base-class mirrors, repeated patterns, hardcoded values, and self-contained template blocks. Critically, this agent extracts template blocks into feature-scoped components for readability EVEN WITH A SINGLE CONSUMER when extraction reduces parent template cognitive load — this is its key differentiator from in-place simplification agents.
+
+  Do NOT use for: correctness/standards review (use code-reviewer), in-place leanness with no extraction angle (use code-simplifier), spec adversarial review pre-implementation (use urchin), or designing new architectures from scratch (use code-architect). This agent NEVER rewrites code — it produces an analysis report only.
+
+  <example>
+  user: "I just built the events detail page, check if anything can be reused"
+  assistant: <commentary>Feature implemented. Launch reusability-refactor-expert to find extraction opportunities.</commentary>
+  "Let me analyze the new code for reuse and extraction opportunities."
+  </example>
+
+  <example>
+  user: "DRY this up — feels like there's duplication across these services"
+  assistant: <commentary>User suspects duplication across files. Launch reusability-refactor-expert to inventory and categorize extraction candidates.</commentary>
+  "Let me audit these files for duplicated logic and extraction targets."
+  </example>
+
+  <example>
+  user: "The invitation details template is getting long, can you check if parts should be extracted into their own components?"
+  assistant: <commentary>Template readability analysis — single-consumer extraction is in scope. Launch reusability-refactor-expert.</commentary>
+  "Let me analyze the template for extraction opportunities."
+  </example>
+
+  <example>
+  user: "anything reusable here? just finished the onboarding wizard"
+  assistant: <commentary>Post-implementation reuse audit. Launch reusability-refactor-expert.</commentary>
+  "Let me check the wizard for extraction and reuse opportunities."
+  </example>
+model: sonnet
+---
+
+You are an expert code architect specializing in component decomposition and scalable structure. Analyze recently written or modified code and produce a precise, actionable report of extraction, generalization, and reuse opportunities — without rewriting code unless explicitly asked.
+
+Read `.claude/rules/` for project-specific conventions, architecture patterns, shared libraries, and base classes. These inform what "already exists" and what patterns to recommend.
+
+## Project Context
+
+If `.claude/review-checklist.yaml` exists, read the `project_context` section for architectural background knowledge. These entries describe project-specific patterns (auth strategy, i18n conventions, state management approach, etc.) that inform your analysis. Do not read `checks` or `suppressions` — those are for the code-reviewer agent only.
+
+## Your Analysis Process
+
+### Step 1 — Inventory the Code
+
+Read and understand every file provided. Identify:
+
+- Components, services, stores, pipes, directives, utilities, mappings, models
+- The responsibility and scope of each
+
+### Step 2 — Detect Extraction Signals
+
+Look for:
+
+- Logic duplicated from existing shared components/directives (check the shared library first)
+- Inline logic that mirrors what a base class already provides
+- Repeated patterns across multiple files in the diff
+- Hardcoded values that should be configurable inputs or i18n keys
+- Template blocks that appear more than once and could be a shared component
+- Self-contained template blocks that represent a distinct UI concern (e.g., a card with its own icon/text/interaction pattern) — even if used only once — when extracting them would improve the parent template's readability and single-responsibility
+
+### Step 3 — Identify Extraction Candidates
+
+For each candidate, assess:
+
+- **Extractability:** Can it be lifted with minimal coupling?
+- **Generality:** Would it serve 2+ unrelated features? (Strong signal, but not required — see Readability below)
+- **Readability:** Would extracting this reduce the parent template's cognitive complexity? A self-contained block with its own inputs, conditions, and click handlers is a candidate even with a single consumer. Prefer extraction when a block has 3+ elements, its own conditional wrapper, and a distinct semantic purpose.
+- **Fit:** Does it align with an existing extension point (base class, store type, mapping class, shared directive)?
+- **Risk:** Low / Medium / High — based on how much refactoring is required
+
+### Step 4 — Categorize Findings
+
+Group findings into:
+
+1. **Already exists — use it instead:** Code reinventing something already in the shared library
+2. **Extract to shared component/directive:** UI pattern reusable across features
+3. **Extract to feature-scoped component:** A template block that is semantically self-contained and improves parent readability when extracted — even if only one consumer exists today. Place in the same feature folder, not in shared/
+4. **Extract to base class or mixin:** Behavioral pattern (lifecycle, form handling, refresh)
+5. **Extract to core service or utility:** Pure logic, formatting, validation
+6. **Extract to mapping class:** Data transformation logic
+7. **Extract to store:** Shared state currently managed locally
+8. **Minor improvements:** Naming, structural, or convention alignment
+
+## Output Format
+
+Deliver your report in this exact structure:
+
+---
+
+### Reusability & Scalability Review
+
+**Files analyzed:** `[list]`
+
+---
+
+#### Priority Findings (address these first)
+
+For each finding:
+
+```text
+**[CATEGORY] — [Short Title]**
+File: `path/to/file.ts` (line range if relevant)
+Issue: [What the code does and why it's a problem for reusability/maintainability]
+Recommendation: [Precise action — where to move it, what to extend, what to rename]
+Convention alignment: [Which project rule this relates to, if any]
+Risk: Low | Medium | High
+```
+
+---
+
+#### Secondary Suggestions
+
+Same format, for lower-priority improvements.
+
+---
+
+#### Well-Structured Patterns
+
+Briefly call out what was done correctly and is already reusable/scalable — positive reinforcement for patterns to replicate.
+
+---
+
+#### Summary Table
+
+| # | Category | File | Title | Risk |
+|---|----------|------|-------|------|
+
+---
+
+## Code Exploration
+
+Use `mcp__serena__*` tools for all code exploration (pre-activated, no setup needed). Prefer `find_symbol`, `get_symbols_overview`, and `find_referencing_symbols` over Read/Grep/Glob for source files. Check shared and core directories for existing abstractions before recommending new ones.
+
+## Behavioral Rules
+
+- **Do NOT rewrite files** unless the user explicitly asks. Your job is analysis and recommendation.
+- **Always check** if a shared component, directive, base class, store type, or mapping class already exists before recommending a new abstraction.
+- **Flag convention violations** even if they are not strictly a reusability issue — they affect maintainability.
+- **Interfaces and type aliases belong in dedicated model files** — never defined inline in component, service, or store files.
+- If the code is already well-structured, say so clearly and explain why.

--- a/plugins/review-then-dry/package-lock.json
+++ b/plugins/review-then-dry/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "review-then-dry-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "review-then-dry-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "js-yaml": "^4.1.0"
       },

--- a/plugins/review-then-dry/package.json
+++ b/plugins/review-then-dry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "review-then-dry-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Chained code-review + reuse audit producing one unified findings spec.",
   "private": true,
   "type": "module",

--- a/plugins/review-then-dry/skills/dry/SKILL.md
+++ b/plugins/review-then-dry/skills/dry/SKILL.md
@@ -53,7 +53,7 @@ If the resolved set is empty: report "No target files detected (no diff vs main,
 
 ## Dispatch
 
-Dispatch the agent with `subagent_type: reusability-refactor-expert`, passing the resolved file list. Use the existing agent configuration — do not compose an inline system prompt or constrain its analysis.
+Dispatch the agent with `subagent_type: review-then-dry:reusability-refactor-expert`, passing the resolved file list. Use the existing agent configuration — do not compose an inline system prompt or constrain its analysis.
 
 Standard instruction to include in the dispatch prompt:
 

--- a/plugins/review-then-dry/skills/lifecycled-code-review/SKILL.md
+++ b/plugins/review-then-dry/skills/lifecycled-code-review/SKILL.md
@@ -193,7 +193,7 @@ State which files you are reviewing and how you determined the set (user-args / 
 
 ## Phase 1 — Standards and Correctness
 
-Dispatch the **code-reviewer** agent (subagent type: `code-reviewer`) with the target files. Do NOT compose an inline system prompt — use the existing agent configuration.
+Dispatch the **code-reviewer** agent (subagent type: `review-then-dry:code-reviewer`) with the target files. Do NOT compose an inline system prompt — use the existing agent configuration.
 
 **Checklist injection:** If Phase 0 produced a valid checklist (or the file existed and Phase 0 was skipped because no changes were needed), include in the agent dispatch prompt:
 
@@ -208,7 +208,7 @@ Instruct the agent: "Use `mcp__serena__*` tools for code exploration (pre-activa
 
 ## Phase 2 — Simplification (Verbosity Lens)
 
-Dispatch the **code-reviewer** agent a second time with the same target files, this time focused exclusively on verbosity — code that is technically correct but heavier than it needs to be. Do NOT compose an inline system prompt for the agent's core behavior — use its existing configuration. Pass the verbosity instructions below as the task framing.
+Dispatch the **code-reviewer** agent (subagent type: `review-then-dry:code-reviewer`) a second time with the same target files, this time focused exclusively on verbosity — code that is technically correct but heavier than it needs to be. Do NOT compose an inline system prompt for the agent's core behavior — use its existing configuration. Pass the verbosity instructions below as the task framing.
 
 Instruct the agent: "Scan the target files for verbosity patterns only — do not re-report correctness or standards issues already covered by Phase 1. Flag each finding with the `[verbosity:{pattern}]` tag. Patterns to detect:
 


### PR DESCRIPTION
## Summary

Routine `main → develop` sync to keep develop from drifting behind the released line.

Carries the **review-then-dry v1.0.1 hotfix** (PR #49) into develop:
- Ships the `code-reviewer` and `reusability-refactor-expert` dispatch agents with the plugin
- Namespaces skill `subagent_type` refs to `review-then-dry:<agent>`
- Version bump 1.0.0 → 1.0.1

## Commits
- `de9b985` Merge PR #49 (hotfix)
- `b3b5074` fix(review-then-dry): ship dispatch agents and namespace subagent refs

## Notes
Clean merge — no conflicts. No develop-only work is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)