### PR TITLE
release: 2026-07-28 — triage v1.1.0, review-then-dry v1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,7 +20,7 @@
     },
     {
       "name": "triage",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "source": "./plugins/triage",
       "description": "Advisory task classifier that routes tasks to the best available skill, agent, or MCP server."
     },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -26,7 +26,7 @@
     },
     {
       "name": "review-then-dry",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "source": "./plugins/review-then-dry",
       "description": "Chained code-review + reuse audit producing one unified findings spec. Node-only, Windows-portable."
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea/
+node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## triage 1.0.0 → 1.1.0
+
+- feat(triage): add /triage-cleanup for pruning stale records, specs, and plans
+- feat(triage): add shared record parsing and a schema validator
+- feat(triage): add SessionStart heartbeat
+- refactor(triage): cut the always-loaded body to 9.4KB
+- refactor(triage): move conditional phases into references
+- refactor(triage): finish removing the flow-table scaffolding
+
+## review-then-dry 1.0.1 → 1.1.0
+
+- feat(review-then-dry): add standalone checklist-lifecycle skill + SessionStart heartbeat
+- refactor(review-then-dry): split lifecycled-code-review, trim dry description
+- chore(review-then-dry): drop refs to removed urchin skill
+
 ## review-then-dry 1.0.0 (new plugin)
 
 - feat(review-then-dry): scaffold Node-only, Windows-portable plugin (no shell/jq/yq/python)

--- a/plugins/review-then-dry/.claude-plugin/plugin.json
+++ b/plugins/review-then-dry/.claude-plugin/plugin.json
@@ -1,9 +1,19 @@
 {
   "name": "review-then-dry",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Chained code-review + reuse audit producing one unified findings spec. Node-only, Windows-portable.",
-  "author": { "name": "mpiccinnonode" },
+  "author": {
+    "name": "mpiccinnonode"
+  },
   "repository": "https://github.com/mpiccinnonode/claude-salad",
   "license": "MIT",
-  "keywords": ["code-review", "dry", "reuse", "refactor", "findings-spec", "orchestrator"]
+  "keywords": [
+    "code-review",
+    "dry",
+    "reuse",
+    "refactor",
+    "findings-spec",
+    "orchestrator",
+    "checklist-lifecycle"
+  ]
 }

--- a/plugins/review-then-dry/CLAUDE.md
+++ b/plugins/review-then-dry/CLAUDE.md
@@ -15,5 +15,15 @@ Three-skill suite backported from personal `~/.claude` skills: `lifecycled-code-
   devDependency for CVE hygiene only; it is NOT installed at plugin-install time.
 - `lifecycled-code-review` is renamed from the built-in `code-review` to avoid collision; the
   orchestrator's `Skill()` calls use the namespaced `review-then-dry:<skill>` form.
+- `checklist-lifecycle` is Phase 0 extracted as a standalone skill, so the lifecycle
+  pass can run without paying for a whole review. It shares `lifecycle-pass.mjs` and
+  `safe-write-yaml.mjs` with `lifecycled-code-review` — no duplicated rule logic.
+- `hooks/checklist-heartbeat.mjs` (SessionStart, auto-discovered from `hooks/hooks.json`)
+  is the clock the lifecycle never had: its thresholds are in days, but Phase 0 only
+  fired when someone ran a review. The hook detects and reports, never writes.
+  Throttled by `--frequency <hours>` (default 24) with state in `${CLAUDE_PLUGIN_DATA}`.
+  It returns `additionalContext` and always exits 0 — on SessionStart, exit 2 prints
+  stderr to the user and bypasses Claude, which is the wrong direction for a note that
+  Claude is supposed to relay.
 - Run tests: `npm test` (uses node:test). Run `npm install` first to pull the js-yaml
   devDependency for the parity test.

--- a/plugins/review-then-dry/agents/reusability-refactor-expert.md
+++ b/plugins/review-then-dry/agents/reusability-refactor-expert.md
@@ -3,7 +3,7 @@ name: reusability-refactor-expert
 description: |
   Use this agent to AUDIT existing code for extraction, reuse, and scalability opportunities — duplicated logic, base-class mirrors, repeated patterns, hardcoded values, and self-contained template blocks. Critically, this agent extracts template blocks into feature-scoped components for readability EVEN WITH A SINGLE CONSUMER when extraction reduces parent template cognitive load — this is its key differentiator from in-place simplification agents.
 
-  Do NOT use for: correctness/standards review (use code-reviewer), in-place leanness with no extraction angle (use code-simplifier), spec adversarial review pre-implementation (use urchin), or designing new architectures from scratch (use code-architect). This agent NEVER rewrites code — it produces an analysis report only.
+  Do NOT use for: correctness/standards review (use code-reviewer), in-place leanness with no extraction angle (use code-simplifier), or designing new architectures from scratch (use code-architect). This agent NEVER rewrites code — it produces an analysis report only.
 
   <example>
   user: "I just built the events detail page, check if anything can be reused"

--- a/plugins/review-then-dry/hooks/checklist-heartbeat.mjs
+++ b/plugins/review-then-dry/hooks/checklist-heartbeat.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Serves: SessionStart hook — independent heartbeat for the review checklist.
+//
+// The lifecycle thresholds in review-checklist.yaml are measured in days, but the
+// only thing that ever evaluated them was Phase 0 of /lifecycled-code-review — an
+// event-driven trigger. A repo nobody reviews for three months accumulates stale
+// checks silently. This hook supplies the missing clock.
+//
+// It DETECTS ONLY. It never edits the checklist; /checklist-lifecycle does that,
+// with user approval. On a finding it returns additionalContext so Claude learns
+// about it and can tell the user. Never exit 2 here: on SessionStart that prints
+// stderr straight to the user and bypasses Claude, which is the opposite chain.
+//
+// Usage: checklist-heartbeat.mjs [--frequency <hours>]   (default 24)
+//
+// Reads the hook event JSON on stdin. Always exits 0 — a session must never
+// break because a maintenance check had a bad day.
+//
+// State: ${CLAUDE_PLUGIN_DATA}/heartbeat-state.json, keyed by checklist path.
+// Unset or unwritable data dir degrades to "check every time", never to a crash.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const LIFECYCLE = join(HERE, "..", "skills", "lifecycled-code-review", "scripts", "lifecycle-pass.mjs");
+
+const quit = () => process.exit(0);
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i === -1 || i === process.argv.length - 1) return fallback;
+  const n = Number(process.argv[i + 1]);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+async function stdin() {
+  if (process.stdin.isTTY) return "";
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// Throttle state. Every failure path returns a no-op pair so a broken or absent
+// data dir means "check anyway" rather than "explode".
+function stateStore() {
+  const dir = process.env.CLAUDE_PLUGIN_DATA;
+  if (!dir) return { read: () => ({}), write: () => {} };
+  const file = join(dir, "heartbeat-state.json");
+  return {
+    read: () => {
+      try { return JSON.parse(readFileSync(file, "utf8")); } catch { return {}; }
+    },
+    write: (obj) => {
+      try { mkdirSync(dir, { recursive: true }); writeFileSync(file, JSON.stringify(obj)); } catch { /* best effort */ }
+    },
+  };
+}
+
+const main = async () => {
+  const frequencyHours = arg("--frequency", 24);
+
+  let event = {};
+  try { event = JSON.parse(await stdin()); } catch { /* fall through to cwd */ }
+  const root = process.env.CLAUDE_PROJECT_DIR || event.cwd || process.cwd();
+
+  const checklist = join(root, ".claude", "review-checklist.yaml");
+  if (!existsSync(checklist)) quit();          // project doesn't use the checklist
+  if (!existsSync(LIFECYCLE)) quit();          // plugin layout changed — stay quiet
+
+  const store = stateStore();
+  const state = store.read();
+  const now = Date.now();
+  const last = state[checklist];
+  if (typeof last === "number" && now - last < frequencyHours * 3600_000) quit();
+
+  let report;
+  try {
+    const today = new Date(now).toISOString().slice(0, 10);
+    report = JSON.parse(execFileSync("node", [LIFECYCLE, checklist, today], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }));
+  } catch {
+    quit();                                     // malformed checklist is Phase 0's problem, not ours
+  }
+
+  state[checklist] = now;
+  store.write(state);
+
+  const counts = [
+    ["prune", report.prune?.length || 0, "staged checks past 45 days with no hits"],
+    ["freeze", report.freeze?.length || 0, "active checks past their miss_streak threshold"],
+    ["expire", report.expire?.length || 0, "suppressions not relevant in 90+ days"],
+    ["glob_warnings", report.glob_warnings?.length || 0, "checks whose glob may not match anything"],
+  ].filter(([, n]) => n > 0);
+
+  if (!counts.length) quit();                   // healthy — say nothing
+
+  const total = counts.reduce((s, [, n]) => s + n, 0);
+  const lines = counts.map(([k, n, why]) => `  - ${k}: ${n} (${why})`).join("\n");
+
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext:
+        `\`.claude/review-checklist.yaml\` has ${total} pending lifecycle change(s):\n${lines}\n\n` +
+        `Tell the user this, in your first reply — they cannot see this note. ` +
+        `Suggest \`/checklist-lifecycle\` to review and apply the changes. ` +
+        `Do not edit the checklist yourself: that skill owns the approval flow and the safe write.`,
+    },
+  }));
+  quit();
+};
+
+main().catch(quit);

--- a/plugins/review-then-dry/hooks/hooks.json
+++ b/plugins/review-then-dry/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/checklist-heartbeat.mjs\" --frequency 24",
+            "timeout": 10,
+            "statusMessage": "Checking review checklist"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/review-then-dry/references/checklist-schema.md
+++ b/plugins/review-then-dry/references/checklist-schema.md
@@ -1,0 +1,81 @@
+# Review Checklist YAML Schema Reference
+
+Source of truth for `.claude/review-checklist.yaml`: fields, lifecycle
+thresholds, suppressions, and the safe-write protocol. Read it before reading
+or writing the checklist.
+
+File: `.claude/review-checklist.yaml`
+
+This section is the single source of truth for the checklist format. All phases reference this section — do not re-describe the schema elsewhere.
+
+## Checks
+
+```yaml
+checks:
+  - id: kebab-case-id          # unique within checks
+    severity: critical          # critical | major | minor
+    rule: "one-line description of what to check"
+    applies_to: "**/*.ts"      # glob — only evaluate on matching files
+    tags: [optional, tags]
+    added_by: seed              # seed | lifecycled-code-review | manual
+    added_date: 2026-04-03     # ISO date
+    status: active              # active | staged | frozen
+    hit_count: 0                # reviews where this check found >= 1 violation
+    miss_streak: 0              # consecutive reviews (on matching files) with 0 hits
+    last_hit: null              # ISO date of last review with a violation
+    last_evaluated: null        # ISO date of last review with matching files
+```
+
+## Suppressions
+
+```yaml
+suppressions:
+  - id: kebab-case-id          # unique within suppressions
+    pattern: "what the agent would flag"
+    reason: "why this is not a real issue"
+    applies_to: "**/*.ts"      # optional — scope the suppression
+    added_by: lifecycled-code-review       # lifecycled-code-review | manual
+    added_date: 2026-04-03
+    last_relevant: 2026-04-03  # last review where this suppression prevented a false positive
+    status: active              # active | expired
+```
+
+## Project Context
+
+```yaml
+project_context:
+  - key: descriptive-key
+    context: "free-text domain knowledge injected into every review"
+```
+
+## Lifecycle Thresholds
+
+| Severity | miss_streak to freeze | Rationale |
+|---|---|---|
+| critical | 25 | Security/correctness — rare violations still important |
+| major | 15 | Standard architectural checks |
+| minor | 8 | Style/naming — team internalizes quickly |
+
+- **Staged → Active:** when `hit_count >= 2` (violations in 2+ separate reviews)
+- **Staged → Removed:** when `added_date > 45 days` ago AND `hit_count == 0`
+- **Active → Frozen:** when `miss_streak` exceeds severity threshold
+- **Frozen → Active:** manual reset OR agent finds matching violation via `.claude/rules/` fallback
+- **Suppression → Expired:** when `last_relevant > 90 days` ago
+- **Staged cap:** maximum 30 staged checks; when exceeded, evict oldest with `hit_count == 0` (FIFO)
+
+## Safety Protocol
+
+Every write to `review-checklist.yaml` is performed by `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/safe-write-yaml.mjs` (spec §1.2.4):
+
+```bash
+cat <<'YAML' | node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/safe-write-yaml.mjs" --path <abs-path>
+# ...new YAML content on stdin...
+YAML
+```
+
+Contract: backup existing → atomic rename write → delete `.bak` on success. Emits `{"path","bak_deleted","existed_before"}` on stdout. Non-zero + stderr on I/O failure leaves `.bak` in place.
+
+**On next read**, if YAML fails to parse:
+
+- If `.bak` exists — restore from `.bak`, warn user, retry.
+- If no `.bak` — rename to `.corrupt`, warn user, proceed without checklist.

--- a/plugins/review-then-dry/references/findings-spec.md
+++ b/plugins/review-then-dry/references/findings-spec.md
@@ -1,0 +1,155 @@
+# Findings Spec Generation
+
+How to turn triaged findings into a durable spec file, plus the spec template
+itself. Read it after the user has triaged findings — unless an orchestrator
+told you to defer spec generation.
+
+Runs after the user has triaged all findings (accept/reject/skip). Produces a durable spec file that a future session can pick up to implement the fixes.
+
+**Skip when invoked by an orchestrator.** If the invoking prompt instructs you to defer spec generation (e.g., `/review-then-dry` collecting outputs from multiple skills to synthesize a unified spec), return the report + triage decisions and stop here — write **no** spec file and emit **no** session-end handoff (the orchestrator owns the final report and next-steps). Phase 3 still runs — the checklist learning loop is independent of spec writing.
+
+## Step 1 — Determine Spec Path
+
+1. Run `git branch --show-current` to get the current branch name.
+2. Strip everything up to and including the first `/` (e.g., `feature/3-e2-s1-schermata-di-login` → `3-e2-s1-schermata-di-login`).
+3. **Ask the user for the output path — there is no default.**
+
+> "Where should I write the code-review findings spec? (provide a path, e.g. `docs/specs/<name>.md`)"
+
+   Use the branch slug (from step 2) only as a *suggested filename* in the prompt, not as an auto-applied default directory.
+
+1. Create the parent directory if it does not exist.
+2. If a file already exists at that path (same branch, same date): append a suffix (`-2`, `-3`, etc.) and re-confirm with the user.
+
+## Step 2 — Build the Spec
+
+Generate the spec from the review findings and the user's triage decisions. The spec has five sections:
+
+**Frontmatter:**
+
+```yaml
+---
+slug: {branch-slug}-lifecycled-code-review-findings
+status: draft
+spec-type: lifecycled-code-review-findings
+category: data-only
+branch: {full branch name}
+review-date: {YYYY-MM-DD}
+created: {YYYY-MM-DD}
+---
+```
+
+- `status: draft` — the user sets this to `approved` before implementing the fixes
+- `category: data-only` — marks these as structural (non-visual) fixes, so a downstream implement step can skip any UI design phase
+
+**Intent section:**
+
+```markdown
+## Intent
+
+Code review findings for branch `{branch}`, reviewed {YYYY-MM-DD}.
+{N} findings: {accepted} accepted, {rejected} rejected, {skipped} deferred.
+This spec captures the planned fixes so they can be resolved in a future session.
+```
+
+**Fix sections — one per finding (accepted and skipped only):**
+
+Each finding becomes a numbered section following this structure:
+
+```markdown
+## Fix {N} — {title}
+
+**Status:** {Accepted | Skipped}
+**Severity:** {Critical | Major | Minor} | **{Check | Tag}:** {check-id (status)} or {organic}
+**File(s):** {file paths}
+
+**Current:**
+
+\`\`\`{lang}
+{the relevant code snippet — keep it focused, not the whole file}
+\`\`\`
+
+**Planned change:**
+
+- {bullet points describing the concrete fix}
+
+**{Optional sections as needed: Open question, Risk, Note, Alternative (rejected)}**
+```
+
+Guidelines for writing each fix section:
+
+- **Title:** concise description of the fix, not the problem (e.g., "Lazy-load terminal login route" not "Route is eagerly loaded")
+- **Current:** include only the relevant code snippet — enough to understand what changes, not the whole file. Use the language identifier in the code fence.
+- **Planned change:** specific, actionable bullet points. Reference exact class names, method names, import paths. A future session reading this spec should be able to implement each fix without re-analyzing the codebase.
+- **Severity and check/tag:** carry these directly from the review report findings — they tie the spec back to the checklist for traceability.
+
+**Rejected findings** are excluded from the fix sections. They feed into Phase 3 as suppression candidates — they don't belong in an implementation spec.
+
+**Deferred section:**
+
+```markdown
+## Deferred (not in scope)
+
+- **{title}** — {one-line reason for deferral}
+```
+
+Include findings from the review that were identified but explicitly recommended for deferral (from the Refactoring Opportunities section or findings the agents flagged as low-priority). Also include any finding the user marked as **Skip** with a note that it was deferred by the reviewer.
+
+**Execution order section:**
+
+```markdown
+## Execution order
+
+1. Fix {N} ({reason for ordering — e.g., "investigate first", "quick independent change", "interdependent with Fix M"})
+2. Fix {M} ...
+...
+{last}. Run lint + tests to verify
+```
+
+Order fixes by:
+
+1. Investigation-required fixes first (unknowns resolved early)
+2. Independent quick wins next
+3. Interdependent changes grouped together
+4. Style/naming fixes last
+5. Always end with a verification step
+
+**Implementation Plan section (implementer compatibility):**
+
+```markdown
+## Implementation Plan
+
+### Files to modify
+
+- {path} — Fix {N}: {one-line summary}
+- {path} — Fix {M}, Fix {P}: {one-line summary}
+
+### Files to create
+
+- {path} — Fix {N}: {one-line summary}
+(or "None" if no new files are needed)
+
+### Architecture notes
+
+Fixes are independent unless noted in the execution order. Follow the fix sections
+above for detailed planned changes per file.
+```
+
+This section exists so a downstream implement step can consume the spec using a standard flow — it reads Implementation Plan as the task list.
+
+## Step 3 — Write and Present
+
+1. Write the spec file to the determined path.
+2. Present the path to the user:
+
+> "Findings spec written to `{path}` with `status: draft`.
+>
+> **{N} fixes** ({accepted} accepted, {skipped} deferred) | **{rejected} rejected** (excluded — fed to checklist as suppressions)
+>
+> To resolve in a future session:
+>
+> 1. Review the spec — edit, reorder, or remove fixes as needed
+> 2. Set `status: approved` in the frontmatter
+> 3. Implement the accepted fixes from the spec in a fresh session"
+
+1. Return to the Post-Review Flow — the next step is Phase 3 (Post-Review Learning).

--- a/plugins/review-then-dry/references/post-review-learning.md
+++ b/plugins/review-then-dry/references/post-review-learning.md
@@ -1,0 +1,87 @@
+# Phase 3 — Post-Review Learning
+
+The checklist learning loop: classify findings, track misses, propose
+promotions and suppressions, enforce the staged cap, write updates.
+
+Runs after the user has acted on findings. **All proposed checklist changes require user approval.**
+
+If no checklist file exists AND no findings were accepted/rejected, skip Phase 3 entirely.
+
+## Step 1 — Classify Findings
+
+For each finding from the review, based on the user's action and the finding's tag:
+
+| User Action | Finding Tag | Checklist Update |
+|---|---|---|
+| Accepted | `[check:{id}]` | **Hit:** increment `hit_count`, reset `miss_streak` to 0, set `last_hit` to today |
+| Accepted | `[staged]` + `[check:{id}]` | Same as above — staged checks track hits identically |
+| Accepted | `[organic]` | **New check candidate:** generate a staged check from this finding |
+| Accepted | `[verbosity:{pattern}]` | **Verbosity check candidate:** if a `verbosity-{pattern}` check already exists, treat as a hit. Otherwise generate a staged check with id `verbosity-{pattern}`, severity `minor`, tags `[verbosity]`, rule text summarizing the pattern |
+| Rejected | `[verbosity:{pattern}]` | **Suppression candidate:** generate a suppression scoped to that verbosity pattern (prevents re-flagging in future reviews where the verbosity is intentional — e.g., boundary validation the agent misread as defensive-duplicate) |
+| Rejected | Any other tag | **Suppression candidate:** generate a suppression entry |
+| Skipped | Any tag | **Neutral:** no tracking update |
+
+Additionally: compare accepted `[organic]` findings against frozen checks (see Schema Reference for fuzzy matching). If a match is found, **reactivate the frozen check** (`status → active`, `miss_streak → 0`, increment `hit_count`) instead of creating a new staged entry.
+
+## Step 2 — Track Misses
+
+For each `active` or `staged` check: if the reviewed files included files matching its `applies_to` glob, but the check produced no findings in this review, increment `miss_streak` by 1 and set `last_evaluated` to today.
+
+Checks whose `applies_to` did not match any reviewed file: no change (don't penalize for irrelevant reviews).
+
+## Step 3 — Identify Promotions
+
+Any staged check that now has `hit_count >= 2`: propose promotion to `active`.
+
+## Step 4 — Enforce Staged Cap
+
+Offloaded to `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs` (spec §1.2.3). First, merge new candidates into a scratch copy of the checklist, then run:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs" --yaml <scratch-yaml-abs> --cap 30
+```
+
+Contract: stdout JSON `{"staged_count":N,"over_cap":bool,"eviction_candidates":[{id, added_date, hit_count}]}`. Candidates = staged entries with `hit_count == 0`, sorted by `added_date` ascending, sliced to the overflow count (staged_count − cap). Non-zero + stderr on missing/invalid argv or malformed YAML. Halt on non-zero. Include returned `eviction_candidates` in the proposal presented to the user.
+
+## Step 5 — Present Proposed Changes
+
+> "**Post-review learning** proposes these checklist updates:
+>
+> **Hit tracking updates:** {N} checks
+> {list: id, hit_count (old → new), miss_streak (old → new)}
+>
+> **Miss tracking updates:** {N} checks
+> {list: id, miss_streak (old → new)}
+>
+> **New staged checks:** {M}
+> {for each: id, severity, rule, applies_to}
+>
+> **New suppressions:** {K}
+> {for each: id, pattern, reason (pending — will ask)}
+>
+> **Promotions (staged → active):** {P}
+> {list: id, hit_count}
+>
+> **Reactivations (frozen → active):** {R}
+> {list: id, matching finding}
+>
+> **Evictions (staged cap overflow):** {E}
+> {list: id, added_date, hit_count}
+>
+> Apply these changes? (yes / no / edit)"
+
+## Step 6 — Collect Suppression Reasons
+
+For each new suppression the user approved, ask:
+
+> "Want to add a reason for the `{id}` suppression? It helps future reviews understand why this is not a real issue. (Enter reason or press Enter to skip)"
+
+If the user provides a reason, update the `reason` field. If not, keep `"User rejected — pending explanation"`.
+
+## Step 7 — Write Updates
+
+On approval: if no checklist file exists yet, create it with `version: 1` and the new entries. If the file exists, update it following the Safety Protocol (backup → write → delete backup).
+
+On rejection: discard all proposed changes. The review findings are still implemented — only the checklist metadata updates are skipped.
+
+On edit: let user specify which changes to apply, write only those.

--- a/plugins/review-then-dry/references/seed-mode.md
+++ b/plugins/review-then-dry/references/seed-mode.md
@@ -1,0 +1,81 @@
+# Seed Mode
+
+Alternative entry point (`--seed`): bootstraps the review checklist from the
+project's existing `.claude/rules/` files.
+
+Alternative entry point: `/lifecycled-code-review --seed`
+
+Seeds the review checklist from existing `.claude/rules/` files. All generated checks start as `staged` — they must prove value through the lifecycle before promoting to `active`.
+
+## Step 1 — Read Rules
+
+Read all files matching `.claude/rules/**/*.md`. For each file, identify individual rules — look for:
+
+- Bullet points or numbered lists describing conventions
+- Headings followed by prescriptive statements
+- Bold "MUST", "should", "never" statements
+
+## Step 2 — Generate Check Candidates
+
+For each identified rule, generate a check entry:
+
+- **id:** kebab-case from the rule's key phrase, max 50 characters
+- **severity:** infer from language:
+  - `MUST`, `never`, `always` + safety/correctness context → `critical`
+  - `MUST`, `should` + architecture/pattern context → `major`
+  - Convention, preference, naming, style → `minor`
+- **rule:** condense to one clear line
+- **applies_to:** infer a glob from file type context in the rule (e.g., "components" → `**/*.component.ts`, "services" → `**/*.service.ts`). Default to `**/*.ts` if unclear.
+- **tags:** infer from the rule file location (e.g., `angular.md` → `[angular]`, `style.md` → `[style]`)
+
+## Step 3 — Filter
+
+Remove candidates that:
+
+- Are shorter than 10 words (too vague to evaluate)
+- Contain only subjective language ("prefer", "consider", "when possible") without a concrete action verb ("use", "return", "extend", "implement")
+- Describe organizational rules rather than code patterns (e.g., "files should be in src/app/")
+
+## Step 4 — Deduplicate
+
+Compare each candidate against existing checks in `.claude/review-checklist.yaml` (if the file exists). Skip candidates where 3+ significant words (nouns, verbs — not articles/prepositions) match an existing check's `rule`, regardless of the existing check's `status`.
+
+Also deduplicate within the generated candidates — if two rules from different files describe the same check, keep the more specific one.
+
+## Step 5 — Enforce Staged Cap
+
+Offloaded to `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs` (spec §1.2.3). Same contract as Phase 3 Step 4.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs" --yaml <scratch-yaml-abs> --cap 30
+```
+
+If `over_cap` is true, warn the user and present only the top 30 candidates by severity (critical first, then major, then minor, sorted by specificity within severity). The returned `eviction_candidates` list identifies seed-generated entries that would be evicted under FIFO+hit_count=0 rules; use it to drop seed candidates before writing.
+
+## Step 6 — Present to User
+
+> "**Seed from rules:** generated {N} staged check candidates from `.claude/rules/`:
+>
+> **Critical ({n}):**
+> {for each: id — rule — applies_to — source file}
+>
+> **Major ({n}):**
+> {for each: id — rule — applies_to — source file}
+>
+> **Minor ({n}):**
+> {for each: id — rule — applies_to — source file}
+>
+> **Filtered out:** {M} rules (too vague, subjective, or organizational)
+> **Deduplicated:** {D} rules (already covered by existing checks)
+>
+> Options:
+>
+> - **Approve all** — write all candidates to the checklist
+> - **Edit** — select which candidates to include
+> - **Cancel** — discard all candidates"
+
+## Step 7 — Write
+
+On approval: set `added_by: seed`, `added_date: today`, `status: staged`, all lifecycle counters to 0/null. Write following the Safety Protocol.
+
+If the checklist file doesn't exist yet, create it with `version: 1`, the approved checks, empty `suppressions`, and the default `project_context` entries from the template.

--- a/plugins/review-then-dry/skills/checklist-lifecycle/SKILL.md
+++ b/plugins/review-then-dry/skills/checklist-lifecycle/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: checklist-lifecycle
+description: >
+  Run the review checklist's lifecycle pass on its own — prune staged checks that
+  never earned promotion, freeze active checks nobody violates, expire stale
+  suppressions. Use when the SessionStart heartbeat reports pending changes, when
+  the user asks to tidy or prune the review checklist, or before a review on a
+  repo that has not been reviewed in a while. Not a code review — it touches only
+  `.claude/review-checklist.yaml`, never source files.
+allowed-tools: Bash Read
+argument-hint: "[path to review-checklist.yaml]"
+---
+
+# /checklist-lifecycle
+
+Phase 0 of `/lifecycled-code-review` runs the same pass, but only as part of a full
+review. The thresholds are measured in days, so a repo nobody reviews for months
+accumulates stale entries with nothing to notice. This is that pass, standalone.
+
+Detection is the `SessionStart` heartbeat's job; this skill owns the decision and
+the write.
+
+## 1 — Locate the checklist
+
+`$ARGUMENTS` if given, otherwise `.claude/review-checklist.yaml` under the project
+root. If it does not exist, say so and stop — suggest `/lifecycled-code-review --seed`
+to create one. Do not create it here.
+
+## 2 — Run the pass
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/lifecycle-pass.mjs" <checklist-path> $(date -u +%Y-%m-%d)
+```
+
+Read the JSON on stdout: `{prune, freeze, expire, glob_warnings}`. On non-zero exit,
+surface the stderr diagnostic verbatim and stop — do not reimplement the rules here.
+
+If all four arrays are empty, report that the checklist is healthy and stop.
+
+## 3 — Present, and wait
+
+Show every proposed change grouped by kind, each with its id, its rule text, and the
+date that triggered it. State the threshold that fired so the reasoning is visible:
+45 days for prune, 90 for expire, and the per-severity `miss_streak` for freeze.
+
+Then stop and ask which to apply — all, some, or none. **Never write without an
+answer.** These entries encode the team's own review knowledge; a check that never
+fired may mean the team internalised it, or may mean nobody looks at that dimension.
+The script cannot tell those apart and neither can you. Say so when a finding looks
+like it could be either.
+
+## 4 — Apply what was approved
+
+- **prune** — remove the check from `checks`
+- **freeze** — set the check's `status` to `frozen`
+- **expire** — set the suppression's `status` to `expired` (keep the entry; it is a record)
+- **glob_warnings** — never auto-fix; report and let the user amend the pattern
+
+Leave `last_evaluated` alone. This pass compares dates, it does not evaluate anything
+against code, and bumping it would claim otherwise.
+
+Write through the safe-write script, never with `Edit` — it backs up, writes
+atomically, and drops the `.bak` only on success:
+
+```bash
+cat <<'YAML' | node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/safe-write-yaml.mjs" --path <checklist-path>
+# ...full updated YAML...
+YAML
+```
+
+Preserve the file's existing formatting and section comments. Re-run step 2 afterwards
+and confirm the pass now returns empty.
+
+See `${CLAUDE_PLUGIN_ROOT}/references/checklist-schema.md` for field semantics and the
+full lifecycle state machine.

--- a/plugins/review-then-dry/skills/dry/SKILL.md
+++ b/plugins/review-then-dry/skills/dry/SKILL.md
@@ -10,7 +10,7 @@ description: |
   - Says a template/file is too long and asks if parts should become their own components (single-consumer extraction for readability counts)
   - Points at a folder/module asking for an "extraction review" or "scaffolding review"
 
-  Do NOT fire for: bug fixes, test failures, runtime errors, generic "review my code" (use lifecycled-code-review), renames, in-place tidying, UX critique, spec review pre-implementation (use urchin), or new architecture design.
+  Do NOT fire for: bug fixes, test failures, runtime errors, generic "review my code" (use lifecycled-code-review), renames, in-place tidying, UX critique, or new architecture design.
 allowed-tools:
   - Read
   - Bash
@@ -31,7 +31,6 @@ A thin, one-shot dispatcher around the `reusability-refactor-expert` agent. The 
 
 - **`/dry` (this skill):** "Find what to extract" — duplication, reuse candidates, single-consumer template extraction for readability. Read-only audit.
 - **`/lifecycled-code-review`:** Full two-pass review (correctness + reuse + simplification + checklist). Use before PRs.
-- **`urchin`:** Spec adversarial review BEFORE implementation.
 - **code-simplifier:** In-place leanness (delete unused, inline single-use) with no extraction.
 - **code-architect:** Designs new architectures pre-implementation.
 

--- a/plugins/review-then-dry/skills/dry/SKILL.md
+++ b/plugins/review-then-dry/skills/dry/SKILL.md
@@ -1,16 +1,7 @@
 ---
 name: dry
 description: |
-  Use this skill for a read-only audit of existing code to find what could be extracted, shared, or deduplicated — never to rewrite. User intent is "tell me what to pull out" or "where's the duplication", not "fix it".
-
-  Fire when the user:
-  - Types `/dry`, "DRY this up", "deduplicate", or asks "anything reusable?", "what can be extracted?", "should this be a shared component?"
-  - Announces a feature/page/component done and asks for a reuse or extraction pass
-  - Suspects duplication across N files (mappers, services, tiles, components) and wants it inventoried
-  - Says a template/file is too long and asks if parts should become their own components (single-consumer extraction for readability counts)
-  - Points at a folder/module asking for an "extraction review" or "scaffolding review"
-
-  Do NOT fire for: bug fixes, test failures, runtime errors, generic "review my code" (use lifecycled-code-review), renames, in-place tidying, UX critique, or new architecture design.
+  Read-only audit of existing code for what can be extracted, shared, or deduplicated — it reports, it never rewrites. Use when the intent is "tell me what to pull out" or "where is the duplication", including when a file or template is simply too long and parts should become their own components (single-consumer extraction counts). Not for correctness review — that is lifecycled-code-review.
 allowed-tools:
   - Read
   - Bash

--- a/plugins/review-then-dry/skills/lifecycled-code-review/SKILL.md
+++ b/plugins/review-then-dry/skills/lifecycled-code-review/SKILL.md
@@ -38,83 +38,14 @@ Parse `$ARGUMENTS` before doing anything else:
 - If `$ARGUMENTS` contains `--simplify-only`: skip Phase 1 entirely. Run Phase 0 → Phase 2 (with the Simplification lens only) → triage → Phase 3. Use when you want a leanness pass on already-reviewed or already-merged code.
 - Otherwise: proceed with the standard review flow (Phase 0 → Phase 1 → Phase 2 → Phase 3).
 
-## Review Checklist YAML Schema Reference
+## Review Checklist
 
-File: `.claude/review-checklist.yaml`
+The checklist lives at `.claude/review-checklist.yaml`. Its schema — fields,
+lifecycle thresholds, suppressions, and the mandatory safe-write protocol — is
+the source of truth in `${CLAUDE_PLUGIN_ROOT}/references/checklist-schema.md`.
+Read it before touching the file; never hand-write the YAML from memory.
 
-This section is the single source of truth for the checklist format. All phases reference this section — do not re-describe the schema elsewhere.
-
-### Checks
-
-```yaml
-checks:
-  - id: kebab-case-id          # unique within checks
-    severity: critical          # critical | major | minor
-    rule: "one-line description of what to check"
-    applies_to: "**/*.ts"      # glob — only evaluate on matching files
-    tags: [optional, tags]
-    added_by: seed              # seed | lifecycled-code-review | manual
-    added_date: 2026-04-03     # ISO date
-    status: active              # active | staged | frozen
-    hit_count: 0                # reviews where this check found >= 1 violation
-    miss_streak: 0              # consecutive reviews (on matching files) with 0 hits
-    last_hit: null              # ISO date of last review with a violation
-    last_evaluated: null        # ISO date of last review with matching files
-```
-
-### Suppressions
-
-```yaml
-suppressions:
-  - id: kebab-case-id          # unique within suppressions
-    pattern: "what the agent would flag"
-    reason: "why this is not a real issue"
-    applies_to: "**/*.ts"      # optional — scope the suppression
-    added_by: lifecycled-code-review       # lifecycled-code-review | manual
-    added_date: 2026-04-03
-    last_relevant: 2026-04-03  # last review where this suppression prevented a false positive
-    status: active              # active | expired
-```
-
-### Project Context
-
-```yaml
-project_context:
-  - key: descriptive-key
-    context: "free-text domain knowledge injected into every review"
-```
-
-### Lifecycle Thresholds
-
-| Severity | miss_streak to freeze | Rationale |
-|---|---|---|
-| critical | 25 | Security/correctness — rare violations still important |
-| major | 15 | Standard architectural checks |
-| minor | 8 | Style/naming — team internalizes quickly |
-
-- **Staged → Active:** when `hit_count >= 2` (violations in 2+ separate reviews)
-- **Staged → Removed:** when `added_date > 45 days` ago AND `hit_count == 0`
-- **Active → Frozen:** when `miss_streak` exceeds severity threshold
-- **Frozen → Active:** manual reset OR agent finds matching violation via `.claude/rules/` fallback
-- **Suppression → Expired:** when `last_relevant > 90 days` ago
-- **Staged cap:** maximum 30 staged checks; when exceeded, evict oldest with `hit_count == 0` (FIFO)
-
-### Safety Protocol
-
-Every write to `review-checklist.yaml` is performed by `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/safe-write-yaml.mjs` (spec §1.2.4):
-
-```bash
-cat <<'YAML' | node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/safe-write-yaml.mjs" --path <abs-path>
-# ...new YAML content on stdin...
-YAML
-```
-
-Contract: backup existing → atomic rename write → delete `.bak` on success. Emits `{"path","bak_deleted","existed_before"}` on stdout. Non-zero + stderr on I/O failure leaves `.bak` in place.
-
-**On next read**, if YAML fails to parse:
-
-- If `.bak` exists — restore from `.bak`, warn user, retry.
-- If no `.bak` — rename to `.corrupt`, warn user, proceed without checklist.
+---
 
 ## Phase 0 — Lifecycle Pass
 
@@ -316,316 +247,32 @@ After both review agents return (and after any cross-check verification of their
 
 ## Findings Spec Generation
 
-Runs after the user has triaged all findings (accept/reject/skip). Produces a durable spec file that a future session can pick up to implement the fixes.
+Runs after the user has triaged all findings, producing a spec a future session
+can pick up. **Skip it entirely when an orchestrator (e.g. `/review-then-dry`)
+says it owns the final report** — return the report plus triage decisions and
+stop. Phase 3 still runs either way.
 
-**Skip when invoked by an orchestrator.** If the invoking prompt instructs you to defer spec generation (e.g., `/review-then-dry` collecting outputs from multiple skills to synthesize a unified spec), return the report + triage decisions and stop here — write **no** spec file and emit **no** session-end handoff (the orchestrator owns the final report and next-steps). Phase 3 still runs — the checklist learning loop is independent of spec writing.
+When it does run, follow
+`${CLAUDE_PLUGIN_ROOT}/references/findings-spec.md` for the path rules and the
+spec template.
 
-### Step 1 — Determine Spec Path
-
-1. Run `git branch --show-current` to get the current branch name.
-2. Strip everything up to and including the first `/` (e.g., `feature/3-e2-s1-schermata-di-login` → `3-e2-s1-schermata-di-login`).
-3. **Ask the user for the output path — there is no default.**
-
-> "Where should I write the code-review findings spec? (provide a path, e.g. `docs/specs/<name>.md`)"
-
-   Use the branch slug (from step 2) only as a *suggested filename* in the prompt, not as an auto-applied default directory.
-
-1. Create the parent directory if it does not exist.
-2. If a file already exists at that path (same branch, same date): append a suffix (`-2`, `-3`, etc.) and re-confirm with the user.
-
-### Step 2 — Build the Spec
-
-Generate the spec from the review findings and the user's triage decisions. The spec has five sections:
-
-**Frontmatter:**
-
-```yaml
 ---
-slug: {branch-slug}-lifecycled-code-review-findings
-status: draft
-spec-type: lifecycled-code-review-findings
-category: data-only
-branch: {full branch name}
-review-date: {YYYY-MM-DD}
-created: {YYYY-MM-DD}
----
-```
-
-- `status: draft` — the user sets this to `approved` before implementing the fixes
-- `category: data-only` — marks these as structural (non-visual) fixes, so a downstream implement step can skip any UI design phase
-
-**Intent section:**
-
-```markdown
-## Intent
-
-Code review findings for branch `{branch}`, reviewed {YYYY-MM-DD}.
-{N} findings: {accepted} accepted, {rejected} rejected, {skipped} deferred.
-This spec captures the planned fixes so they can be resolved in a future session.
-```
-
-**Fix sections — one per finding (accepted and skipped only):**
-
-Each finding becomes a numbered section following this structure:
-
-```markdown
-## Fix {N} — {title}
-
-**Status:** {Accepted | Skipped}
-**Severity:** {Critical | Major | Minor} | **{Check | Tag}:** {check-id (status)} or {organic}
-**File(s):** {file paths}
-
-**Current:**
-
-\`\`\`{lang}
-{the relevant code snippet — keep it focused, not the whole file}
-\`\`\`
-
-**Planned change:**
-
-- {bullet points describing the concrete fix}
-
-**{Optional sections as needed: Open question, Risk, Note, Alternative (rejected)}**
-```
-
-Guidelines for writing each fix section:
-
-- **Title:** concise description of the fix, not the problem (e.g., "Lazy-load terminal login route" not "Route is eagerly loaded")
-- **Current:** include only the relevant code snippet — enough to understand what changes, not the whole file. Use the language identifier in the code fence.
-- **Planned change:** specific, actionable bullet points. Reference exact class names, method names, import paths. A future session reading this spec should be able to implement each fix without re-analyzing the codebase.
-- **Severity and check/tag:** carry these directly from the review report findings — they tie the spec back to the checklist for traceability.
-
-**Rejected findings** are excluded from the fix sections. They feed into Phase 3 as suppression candidates — they don't belong in an implementation spec.
-
-**Deferred section:**
-
-```markdown
-## Deferred (not in scope)
-
-- **{title}** — {one-line reason for deferral}
-```
-
-Include findings from the review that were identified but explicitly recommended for deferral (from the Refactoring Opportunities section or findings the agents flagged as low-priority). Also include any finding the user marked as **Skip** with a note that it was deferred by the reviewer.
-
-**Execution order section:**
-
-```markdown
-## Execution order
-
-1. Fix {N} ({reason for ordering — e.g., "investigate first", "quick independent change", "interdependent with Fix M"})
-2. Fix {M} ...
-...
-{last}. Run lint + tests to verify
-```
-
-Order fixes by:
-
-1. Investigation-required fixes first (unknowns resolved early)
-2. Independent quick wins next
-3. Interdependent changes grouped together
-4. Style/naming fixes last
-5. Always end with a verification step
-
-**Implementation Plan section (implementer compatibility):**
-
-```markdown
-## Implementation Plan
-
-### Files to modify
-
-- {path} — Fix {N}: {one-line summary}
-- {path} — Fix {M}, Fix {P}: {one-line summary}
-
-### Files to create
-
-- {path} — Fix {N}: {one-line summary}
-(or "None" if no new files are needed)
-
-### Architecture notes
-
-Fixes are independent unless noted in the execution order. Follow the fix sections
-above for detailed planned changes per file.
-```
-
-This section exists so a downstream implement step can consume the spec using a standard flow — it reads Implementation Plan as the task list.
-
-### Step 3 — Write and Present
-
-1. Write the spec file to the determined path.
-2. Present the path to the user:
-
-> "Findings spec written to `{path}` with `status: draft`.
->
-> **{N} fixes** ({accepted} accepted, {skipped} deferred) | **{rejected} rejected** (excluded — fed to checklist as suppressions)
->
-> To resolve in a future session:
->
-> 1. Review the spec — edit, reorder, or remove fixes as needed
-> 2. Set `status: approved` in the frontmatter
-> 3. Implement the accepted fixes from the spec in a fresh session"
-
-1. Return to the Post-Review Flow — the next step is Phase 3 (Post-Review Learning).
 
 ## Phase 3 — Post-Review Learning
 
-Runs after the user has acted on findings. **All proposed checklist changes require user approval.**
+Runs after the user has acted on findings, and feeds the checklist's hit/miss
+telemetry so useless checks decay and proven ones get promoted. **All proposed
+changes require user approval.**
 
-If no checklist file exists AND no findings were accepted/rejected, skip Phase 3 entirely.
+Skip entirely when no checklist file exists AND nothing was accepted or
+rejected. Otherwise follow
+`${CLAUDE_PLUGIN_ROOT}/references/post-review-learning.md`.
 
-### Step 1 — Classify Findings
-
-For each finding from the review, based on the user's action and the finding's tag:
-
-| User Action | Finding Tag | Checklist Update |
-|---|---|---|
-| Accepted | `[check:{id}]` | **Hit:** increment `hit_count`, reset `miss_streak` to 0, set `last_hit` to today |
-| Accepted | `[staged]` + `[check:{id}]` | Same as above — staged checks track hits identically |
-| Accepted | `[organic]` | **New check candidate:** generate a staged check from this finding |
-| Accepted | `[verbosity:{pattern}]` | **Verbosity check candidate:** if a `verbosity-{pattern}` check already exists, treat as a hit. Otherwise generate a staged check with id `verbosity-{pattern}`, severity `minor`, tags `[verbosity]`, rule text summarizing the pattern |
-| Rejected | `[verbosity:{pattern}]` | **Suppression candidate:** generate a suppression scoped to that verbosity pattern (prevents re-flagging in future reviews where the verbosity is intentional — e.g., boundary validation the agent misread as defensive-duplicate) |
-| Rejected | Any other tag | **Suppression candidate:** generate a suppression entry |
-| Skipped | Any tag | **Neutral:** no tracking update |
-
-Additionally: compare accepted `[organic]` findings against frozen checks (see Schema Reference for fuzzy matching). If a match is found, **reactivate the frozen check** (`status → active`, `miss_streak → 0`, increment `hit_count`) instead of creating a new staged entry.
-
-### Step 2 — Track Misses
-
-For each `active` or `staged` check: if the reviewed files included files matching its `applies_to` glob, but the check produced no findings in this review, increment `miss_streak` by 1 and set `last_evaluated` to today.
-
-Checks whose `applies_to` did not match any reviewed file: no change (don't penalize for irrelevant reviews).
-
-### Step 3 — Identify Promotions
-
-Any staged check that now has `hit_count >= 2`: propose promotion to `active`.
-
-### Step 4 — Enforce Staged Cap
-
-Offloaded to `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs` (spec §1.2.3). First, merge new candidates into a scratch copy of the checklist, then run:
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs" --yaml <scratch-yaml-abs> --cap 30
-```
-
-Contract: stdout JSON `{"staged_count":N,"over_cap":bool,"eviction_candidates":[{id, added_date, hit_count}]}`. Candidates = staged entries with `hit_count == 0`, sorted by `added_date` ascending, sliced to the overflow count (staged_count − cap). Non-zero + stderr on missing/invalid argv or malformed YAML. Halt on non-zero. Include returned `eviction_candidates` in the proposal presented to the user.
-
-### Step 5 — Present Proposed Changes
-
-> "**Post-review learning** proposes these checklist updates:
->
-> **Hit tracking updates:** {N} checks
-> {list: id, hit_count (old → new), miss_streak (old → new)}
->
-> **Miss tracking updates:** {N} checks
-> {list: id, miss_streak (old → new)}
->
-> **New staged checks:** {M}
-> {for each: id, severity, rule, applies_to}
->
-> **New suppressions:** {K}
-> {for each: id, pattern, reason (pending — will ask)}
->
-> **Promotions (staged → active):** {P}
-> {list: id, hit_count}
->
-> **Reactivations (frozen → active):** {R}
-> {list: id, matching finding}
->
-> **Evictions (staged cap overflow):** {E}
-> {list: id, added_date, hit_count}
->
-> Apply these changes? (yes / no / edit)"
-
-### Step 6 — Collect Suppression Reasons
-
-For each new suppression the user approved, ask:
-
-> "Want to add a reason for the `{id}` suppression? It helps future reviews understand why this is not a real issue. (Enter reason or press Enter to skip)"
-
-If the user provides a reason, update the `reason` field. If not, keep `"User rejected — pending explanation"`.
-
-### Step 7 — Write Updates
-
-On approval: if no checklist file exists yet, create it with `version: 1` and the new entries. If the file exists, update it following the Safety Protocol (backup → write → delete backup).
-
-On rejection: discard all proposed changes. The review findings are still implemented — only the checklist metadata updates are skipped.
-
-On edit: let user specify which changes to apply, write only those.
+---
 
 ## Seed Mode
 
-Alternative entry point: `/lifecycled-code-review --seed`
-
-Seeds the review checklist from existing `.claude/rules/` files. All generated checks start as `staged` — they must prove value through the lifecycle before promoting to `active`.
-
-### Step 1 — Read Rules
-
-Read all files matching `.claude/rules/**/*.md`. For each file, identify individual rules — look for:
-
-- Bullet points or numbered lists describing conventions
-- Headings followed by prescriptive statements
-- Bold "MUST", "should", "never" statements
-
-### Step 2 — Generate Check Candidates
-
-For each identified rule, generate a check entry:
-
-- **id:** kebab-case from the rule's key phrase, max 50 characters
-- **severity:** infer from language:
-  - `MUST`, `never`, `always` + safety/correctness context → `critical`
-  - `MUST`, `should` + architecture/pattern context → `major`
-  - Convention, preference, naming, style → `minor`
-- **rule:** condense to one clear line
-- **applies_to:** infer a glob from file type context in the rule (e.g., "components" → `**/*.component.ts`, "services" → `**/*.service.ts`). Default to `**/*.ts` if unclear.
-- **tags:** infer from the rule file location (e.g., `angular.md` → `[angular]`, `style.md` → `[style]`)
-
-### Step 3 — Filter
-
-Remove candidates that:
-
-- Are shorter than 10 words (too vague to evaluate)
-- Contain only subjective language ("prefer", "consider", "when possible") without a concrete action verb ("use", "return", "extend", "implement")
-- Describe organizational rules rather than code patterns (e.g., "files should be in src/app/")
-
-### Step 4 — Deduplicate
-
-Compare each candidate against existing checks in `.claude/review-checklist.yaml` (if the file exists). Skip candidates where 3+ significant words (nouns, verbs — not articles/prepositions) match an existing check's `rule`, regardless of the existing check's `status`.
-
-Also deduplicate within the generated candidates — if two rules from different files describe the same check, keep the more specific one.
-
-### Step 5 — Enforce Staged Cap
-
-Offloaded to `${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs` (spec §1.2.3). Same contract as Phase 3 Step 4.
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/lifecycled-code-review/scripts/evict-staged.mjs" --yaml <scratch-yaml-abs> --cap 30
-```
-
-If `over_cap` is true, warn the user and present only the top 30 candidates by severity (critical first, then major, then minor, sorted by specificity within severity). The returned `eviction_candidates` list identifies seed-generated entries that would be evicted under FIFO+hit_count=0 rules; use it to drop seed candidates before writing.
-
-### Step 6 — Present to User
-
-> "**Seed from rules:** generated {N} staged check candidates from `.claude/rules/`:
->
-> **Critical ({n}):**
-> {for each: id — rule — applies_to — source file}
->
-> **Major ({n}):**
-> {for each: id — rule — applies_to — source file}
->
-> **Minor ({n}):**
-> {for each: id — rule — applies_to — source file}
->
-> **Filtered out:** {M} rules (too vague, subjective, or organizational)
-> **Deduplicated:** {D} rules (already covered by existing checks)
->
-> Options:
->
-> - **Approve all** — write all candidates to the checklist
-> - **Edit** — select which candidates to include
-> - **Cancel** — discard all candidates"
-
-### Step 7 — Write
-
-On approval: set `added_by: seed`, `added_date: today`, `status: staged`, all lifecycle counters to 0/null. Write following the Safety Protocol.
-
-If the checklist file doesn't exist yet, create it with `version: 1`, the approved checks, empty `suppressions`, and the default `project_context` entries from the template.
+`/lifecycled-code-review --seed` seeds the checklist from the project's
+`.claude/rules/`. Every generated check starts `staged` and must earn promotion
+through the lifecycle. Procedure:
+`${CLAUDE_PLUGIN_ROOT}/references/seed-mode.md`.

--- a/plugins/review-then-dry/test/checklist-heartbeat.test.mjs
+++ b/plugins/review-then-dry/test/checklist-heartbeat.test.mjs
@@ -1,0 +1,109 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOK = fileURLToPath(new URL("../hooks/checklist-heartbeat.mjs", import.meta.url));
+
+const run = (root, dataDir, args = []) =>
+  execFileSync("node", [HOOK, ...args], {
+    encoding: "utf8",
+    input: JSON.stringify({ hook_event_name: "SessionStart", cwd: root }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, CLAUDE_PLUGIN_DATA: dataDir ?? "" },
+  });
+
+const project = (yaml) => {
+  const root = mkdtempSync(join(tmpdir(), "hb-"));
+  if (yaml !== null) {
+    mkdirSync(join(root, ".claude"), { recursive: true });
+    writeFileSync(join(root, ".claude", "review-checklist.yaml"), yaml);
+  }
+  return root;
+};
+
+const dataDir = () => mkdtempSync(join(tmpdir(), "hbdata-"));
+
+// A staged check added long ago with no hits is prunable; the same check added
+// today is not. Dates are literal so the test does not drift.
+const stale = `version: 1
+checks:
+  - id: never-fired
+    severity: minor
+    rule: "placeholder"
+    applies_to: "**/*.ts"
+    added_by: seed
+    added_date: 2020-01-01
+    status: staged
+    hit_count: 0
+    miss_streak: 0
+`;
+
+const fresh = (today) => `version: 1
+checks:
+  - id: brand-new
+    severity: minor
+    rule: "placeholder"
+    applies_to: "**/*.ts"
+    added_by: seed
+    added_date: ${today}
+    status: staged
+    hit_count: 0
+    miss_streak: 0
+`;
+
+test("silent when the project has no checklist", () => {
+  assert.equal(run(project(null), dataDir()), "");
+});
+
+test("silent when nothing is due", () => {
+  const today = new Date().toISOString().slice(0, 10);
+  assert.equal(run(project(fresh(today)), dataDir()), "");
+});
+
+test("reports pending changes as additionalContext for Claude", () => {
+  const out = run(project(stale), dataDir());
+  const payload = JSON.parse(out);
+  assert.equal(payload.hookSpecificOutput.hookEventName, "SessionStart");
+  const ctx = payload.hookSpecificOutput.additionalContext;
+  assert.match(ctx, /prune: 1/);
+  assert.match(ctx, /Tell the user/);
+  assert.match(ctx, /\/checklist-lifecycle/);
+});
+
+test("--frequency suppresses a second run inside the window", () => {
+  const root = project(stale);
+  const data = dataDir();
+  assert.notEqual(run(root, data), "", "first run should report");
+  assert.equal(run(root, data), "", "second run inside the window should stay silent");
+});
+
+test("--frequency 0 disables throttling", () => {
+  const root = project(stale);
+  const data = dataDir();
+  assert.notEqual(run(root, data, ["--frequency", "0"]), "");
+  assert.notEqual(run(root, data, ["--frequency", "0"]), "");
+});
+
+test("no CLAUDE_PLUGIN_DATA degrades to unthrottled, never to a crash", () => {
+  const root = project(stale);
+  assert.notEqual(run(root, null), "");
+  assert.notEqual(run(root, null), "");
+});
+
+test("a corrupt checklist stays silent and exits 0", () => {
+  const root = project("this: is: not: valid: yaml:\n  - [\n");
+  assert.equal(run(root, dataDir()), "");
+});
+
+test("state file is written and keyed by checklist path", () => {
+  const root = project(stale);
+  const data = dataDir();
+  run(root, data);
+  const state = JSON.parse(readFileSync(join(data, "heartbeat-state.json"), "utf8"));
+  const key = join(root, ".claude", "review-checklist.yaml");
+  assert.ok(existsSync(join(data, "heartbeat-state.json")));
+  assert.equal(typeof state[key], "number");
+});

--- a/plugins/triage/.claude-plugin/plugin.json
+++ b/plugins/triage/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "triage",
-  "version": "1.0.0",
-  "description": "Advisory task classifier — reads your installed skills, agents, and MCP servers, classifies a task into a workflow shape, and maps each phase to the best available invocation. Never dispatches agents or edits code.",
+  "version": "1.1.0",
+  "description": "Advisory task classifier — reads your installed skills, agents, and MCP servers, classifies a task into a workflow shape, and maps each phase to the best available invocation. Never dispatches agents or edits code. Ships /triage-cleanup for pruning stale records, specs, and plans.",
   "author": { "name": "mpiccinnonode" },
   "repository": "https://github.com/mpiccinnonode/claude-salad",
   "license": "MIT",
-  "keywords": ["triage", "routing", "skills", "workflow", "onboarding", "mcp"]
+  "keywords": ["triage", "routing", "skills", "workflow", "onboarding", "mcp", "cleanup"]
 }

--- a/plugins/triage/CLAUDE.md
+++ b/plugins/triage/CLAUDE.md
@@ -1,9 +1,20 @@
 # triage plugin — dev notes
 
-Single-skill plugin packaging the `/triage` classifier.
+Two skills: `/triage` (classifier) and `/triage-cleanup` (stale-artifact deletion). They share the
+storage-path convention — cleanup reads from exactly where triage writes.
 
-- Skill body: `skills/triage/SKILL.md`. In-plugin paths use `${CLAUDE_PLUGIN_ROOT}`.
-- Helper scripts: `skills/triage/scripts/*.mjs` — Node only, no shell/jq/python/yq.
-- Each script has a fixed argv signature + stdout contract documented in its header. Three were ported 1:1 from POSIX `.sh`; parity is locked by golden-output tests in `test/`.
+- Skill bodies: `skills/triage/SKILL.md`, `skills/triage-cleanup/SKILL.md`. In-plugin paths use `${CLAUDE_PLUGIN_ROOT}`.
+- Helper scripts: `skills/<skill>/scripts/*.mjs` — Node only, no shell/jq/python/yq.
+- Each script has a fixed argv signature + stdout contract documented in its header. Three triage scripts were ported 1:1 from POSIX `.sh`; parity is locked by golden-output tests in `test/`.
 - `discover-skills.mjs` additionally discovers MCP servers (project `.mcp.json`, `~/.claude.json` per-project entry, and plugin `.mcp.json`).
+- `triage-cleanup` is built on report → confirm → delete: `scan-stale.mjs` classifies stale candidates (deterministic; takes `--now` for testable age math, never deletes), the skill body presents and gates, and `delete-targets.mjs` removes only the confirmed list — refusing any path outside its `--allow-root` jails. Git-merged/tracked checks stay in the skill body (heuristic, not deterministic).
+- Two sanctioned cross-skill references, both because the skills must agree or they silently diverge (see `skills/triage/references/offload-scripts.md` §Exception):
+  - `triage-cleanup` invokes `skills/triage/scripts/resolve-triage-path.mjs` — both skills must agree on *where* records live.
+  - `scan-stale.mjs` and `triage-recall.mjs` both import `skills/triage/scripts/yaml-fields.mjs` — all scripts must agree on *how* a record is read. This module owns field extraction and the schema's allowed status values; nothing that a skill decides belongs in it.
+- `validate-record.mjs` is the schema's enforcement point, called at the end of triage's Phase 5. Exit 1 = violations printed on stdout, and the skill body must fix and re-run. Without it the lifecycle drifts: measured on 35 real records, 2 used `created_at` instead of `created` and 1 had an off-schema status, and all three were invisible to both recall and cleanup.
+- `scan-stale.mjs` asks git for last-commit dates (a fact) but never for merge state (a heuristic — that stays in the skill body). mtime is a checkout timestamp, so it silently reports identical ages for every file in a fresh clone; each candidate carries `ageSource` to say which date it used.
+- `hooks/triage-heartbeat.mjs` (SessionStart, registered in `hooks/hooks.json`) is the clock cleanup otherwise lacks: staleness is measured in days, but only `/triage-cleanup` ever evaluated it, and the repos that need it most are the ones where triage stopped being used — so the triggering event never comes again. Detection only, 24h throttle in `${CLAUDE_PLUGIN_DATA}`, always exits 0, never `exit 2` (on SessionStart that bypasses Claude and prints straight to the user).
+  - It gates on the triage dir *existing and holding a `.yaml`*: `resolve-triage-path.mjs` answers "where records would live", which is a path in any project with a `.claude/` dir, so without the gate the hook would report orphaned specs in repos that never triaged.
+  - Speaks only when something is actionable: `autoDeletable ≥ 1`, or `needsRepair ≥ 1`, or flagged records ≥ `--min-flagged` (default 5). A directory whose every candidate is flag-only has no safe move behind it, and offering cleanup anyway is a recurring nag.
+  - `needsRepair` is keyed on the schema's own field names, not on the tolerant read, so it reaches the same verdict as `validate-record.mjs`. Repair cases are never counted as "likely dead".
 - Run tests: `npm test` (uses node:test, no deps).

--- a/plugins/triage/README.md
+++ b/plugins/triage/README.md
@@ -19,4 +19,19 @@ Advisory task classifier for Claude Code. Describe a task in natural language an
 /triage <task description>
 ```
 
-Triage never dispatches agents or edits code — it recommends and records a triage decision at `.claude/triage/<slug>.yaml` in your project.
+Triage never dispatches agents or edits code — it recommends and records a triage decision at `.claude/triage/<slug>.yaml` in your project. Every record it writes is checked against the schema, so it stays resumable in a later session and closable later on.
+
+### Cleaning up
+
+```text
+/triage-cleanup
+```
+
+Finds finished, abandoned, and forgotten records — plus the specs and plans belonging to work that's over — and deletes only what you confirm. Nothing is removed before you've seen the list: a deterministic scan decides what *could* be stale, you decide what actually goes.
+
+You don't have to remember to run it. A `SessionStart` hook checks the triage directory once a day and mentions it only when something is actually actionable, staying quiet otherwise. It never deletes anything itself. To change the cadence or how insistent it is, edit `hooks/hooks.json`:
+
+```text
+--frequency 24     hours between checks (0 checks every session)
+--min-flagged 5    how many likely-dead records alone are worth mentioning
+```

--- a/plugins/triage/hooks/hooks.json
+++ b/plugins/triage/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/triage-heartbeat.mjs\" --frequency 24 --min-flagged 5",
+            "timeout": 10,
+            "statusMessage": "Checking triage records"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/triage/hooks/triage-heartbeat.mjs
+++ b/plugins/triage/hooks/triage-heartbeat.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+// Serves: SessionStart hook — independent heartbeat for the triage record directory.
+//
+// Staleness in `.claude/triage/` is measured in days, but the only thing that ever
+// evaluated it was /triage-cleanup, which the user has to remember to run. The repos
+// that need it most are the ones where triage stopped being used: measured on a real
+// project, 4 dead in_progress records and 65 stale candidates sat unnoticed while the
+// newest record had gone 81 days untouched. Nothing event-driven can catch that, because
+// the event never comes again. This hook supplies the missing clock.
+//
+// It DETECTS ONLY. It never deletes and never edits a record — /triage-cleanup owns the
+// report → confirm → delete flow, and repairing a malformed record is the user's call.
+// On a finding it returns additionalContext so Claude can tell the user.
+//
+// Never exit 2 here: on SessionStart that prints stderr straight to the user and bypasses
+// Claude, which is the opposite of what this is for. Always exits 0 — a session must never
+// break because a maintenance check had a bad day.
+//
+// Usage: triage-heartbeat.mjs [--frequency <hours>] [--min-flagged <n>]
+//   --frequency    throttle window, default 24
+//   --min-flagged  how many flag-only triage records alone are worth mentioning, default 5
+//
+// Reads the hook event JSON on stdin.
+// State: ${CLAUDE_PLUGIN_DATA}/triage-heartbeat-state.json, keyed by triage dir.
+// Unset or unwritable data dir degrades to "check every time", never to a crash.
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const RESOLVE = join(HERE, "..", "skills", "triage", "scripts", "resolve-triage-path.mjs");
+const SCAN = join(HERE, "..", "skills", "triage-cleanup", "scripts", "scan-stale.mjs");
+
+const quit = () => process.exit(0);
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  if (i === -1 || i === process.argv.length - 1) return fallback;
+  const n = Number(process.argv[i + 1]);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+async function stdin() {
+  if (process.stdin.isTTY) return "";
+  const chunks = [];
+  for await (const c of process.stdin) chunks.push(c);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+// Throttle state. Every failure path returns a no-op pair so a broken or absent
+// data dir means "check anyway" rather than "explode".
+function stateStore() {
+  const dir = process.env.CLAUDE_PLUGIN_DATA;
+  if (!dir) return { read: () => ({}), write: () => {} };
+  const file = join(dir, "triage-heartbeat-state.json");
+  return {
+    read: () => {
+      try { return JSON.parse(readFileSync(file, "utf8")); } catch { return {}; }
+    },
+    write: (obj) => {
+      try { mkdirSync(dir, { recursive: true }); writeFileSync(file, JSON.stringify(obj)); } catch { /* best effort */ }
+    },
+  };
+}
+
+const main = async () => {
+  const frequencyHours = arg("--frequency", 24);
+  const minFlagged = arg("--min-flagged", 5);
+
+  let event = {};
+  try { event = JSON.parse(await stdin()); } catch { /* fall through to cwd */ }
+  const root = process.env.CLAUDE_PROJECT_DIR || event.cwd || process.cwd();
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+
+  if (!home) quit();
+  if (!existsSync(RESOLVE) || !existsSync(SCAN)) quit();   // plugin layout changed — stay quiet
+
+  let triageDir = "";
+  try {
+    triageDir = execFileSync("node", [RESOLVE, "--root", root, "--home", home, "--path-only"], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  } catch {
+    quit();
+  }
+
+  // The resolver answers "where records WOULD live", which is a path even in a project
+  // that has a .claude/ dir and has never triaged anything. Only an existing dir holding
+  // at least one record means this project actually uses triage — without this gate the
+  // hook would report orphaned specs in every repo that has a .claude/ folder.
+  if (!triageDir || !existsSync(triageDir)) quit();
+  try {
+    if (!readdirSync(triageDir).some((f) => f.endsWith(".yaml"))) quit();
+  } catch {
+    quit();
+  }
+
+  const store = stateStore();
+  const state = store.read();
+  const now = Date.now();
+  const last = state[triageDir];
+  if (typeof last === "number" && now - last < frequencyHours * 3600_000) quit();
+
+  let report;
+  try {
+    const today = new Date(now).toISOString().slice(0, 10);
+    report = JSON.parse(execFileSync("node", [SCAN, "--root", root, "--now", today, "--triage-dir", triageDir], {
+      encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    }));
+  } catch {
+    quit();                                     // a broken scan is /triage-cleanup's problem, not ours
+  }
+
+  state[triageDir] = now;
+  store.write(state);
+
+  const candidates = report.candidates ?? [];
+  const autoDeletable = report.summary?.autoDeletable ?? 0;
+  const needsRepair = candidates.filter((c) => c.needsRepair).length + (report.active ?? []).filter((a) => a.needsRepair).length;
+  // Repair cases are counted separately, not as "likely dead" — a mislabelled record is
+  // often live work, and telling the user it looks dead would push them the wrong way.
+  const flaggedRecords = candidates.filter((c) => c.kind === "triage" && c.flagOnly && !c.needsRepair).length;
+
+  // Speak only when there is something to act on. A directory whose every candidate is
+  // flag-only is *not* actionable — offering to clean it would be a recurring nag with no
+  // safe move behind it — unless the dead records have piled up past minFlagged.
+  if (autoDeletable === 0 && needsRepair === 0 && flaggedRecords < minFlagged) quit();
+
+  const lines = [];
+  if (autoDeletable > 0) lines.push(`  - ${autoDeletable} finished or abandoned artifact(s) safe to close out`);
+  if (flaggedRecords > 0) lines.push(`  - ${flaggedRecords} record(s) flagged as likely dead — needs your judgment, never auto-deleted`);
+  if (needsRepair > 0) lines.push(`  - ${needsRepair} record(s) with an off-schema status or date field: repair, don't delete — they may be live work written wrong`);
+
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext:
+        `\`${triageDir}\` has accumulated stale triage artifacts:\n${lines.join("\n")}\n\n` +
+        `Tell the user this, in your first reply — they cannot see this note. ` +
+        `Suggest \`/triage-cleanup\` for the full report and the confirmation gate. ` +
+        `Do not delete or edit anything yourself: that skill owns the approval flow, ` +
+        `and malformed records are fixed with the triage plugin's validate-record.mjs, not by deletion.`,
+    },
+  }));
+  quit();
+};
+
+main().catch(quit);

--- a/plugins/triage/skills/triage-cleanup/SKILL.md
+++ b/plugins/triage/skills/triage-cleanup/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: triage-cleanup
+description: Use when `.claude/triage/` has filled up with finished, abandoned, or forgotten records, or when old `specs/`/`plans/` files are cluttering the repo — including when the user only gestures at the clutter without naming a file. Trigger on requests to clean up, prune, close out, sweep, or tidy triage records, specs, or implementation plans.
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+argument-hint: "[optional: scope hints, e.g. 'drafts only' or a specific age threshold]"
+---
+
+# Triage Cleanup Skill
+
+Find stale triage records, specs, and implementation plans — then **delete the ones the user confirms**. Deletion is destructive, so this skill is built around a hard rule: a deterministic script decides what *could* be stale, the user decides what *actually* goes, and a second jailed script does the removal. Nothing is deleted before the user sees the list and says yes.
+
+## Core Concept
+
+Cleanup is **report → confirm → delete**, never delete-on-sight:
+
+1. **Scan (deterministic)** — `scan-stale.mjs` reads every triage YAML and every spec/plan/doc, classifies each as a stale *candidate* (with a confidence) or *active*, and emits JSON. No judgment, no deletion.
+2. **Present (judgment)** — group candidates by confidence, show what's safe vs. what merely warrants a look, and flag anything not recoverable after deletion.
+3. **Confirm (gate)** — the user approves a concrete list. Low-confidence "flag-only" items are never deleted unless the user picks them by hand.
+4. **Delete (jailed)** — `delete-targets.mjs` removes exactly that list, refusing anything outside the triage/spec/plan roots.
+
+The split matters: the script can't be talked into deleting the wrong thing, and the skill can't delete without showing its work first.
+
+---
+
+## What counts as stale
+
+`scan-stale.mjs` applies these rules. Confidence drives how the candidate is presented — **high** is safe to delete after a glance; **low / flag-only** must never be auto-included.
+
+### Triage records (`.claude/triage/*.yaml`)
+
+| Situation | Verdict | Confidence |
+|---|---|---|
+| `status: abandoned` | stale — explicitly given up | **high** |
+| `status: complete` AND every phase closed out | stale — work finished | **high** |
+| `status: complete` but a phase is still open | stale, but odd — surface the mismatch | medium |
+| `status: draft` older than `--draft-age` (default 30d) | stale — never confirmed | medium |
+| `status: in_progress` untouched longer than `--inprogress-age` (default 60d) | **flag only** — likely dead, but could be real work | low |
+| `status` off-schema (anything but `draft`/`in_progress`/`complete`/`abandoned`) | **flag only** — invisible to recall *and* to every rule above, so it would live forever | low |
+| no `status` field at all | **flag only** — cannot be resumed or closed | low |
+| active drafts, recently-touched in_progress | not a candidate | — |
+
+The last two rows are the lifecycle's blind spots, and deleting is usually the *wrong* fix for them — the record may be live work whose status was written wrong. Offer `validate-record.mjs` (in the `triage` skill's scripts) to repair the record instead, and only delete if the user says the work is over.
+
+Ages come from **git's last-commit date** for tracked files, falling back to mtime only for untracked ones. Each candidate carries `ageSource` saying which. This matters: mtime is stamped at checkout, so on a fresh clone every artifact reports the same fabricated age. Never present an mtime-derived age as authoritative for a tracked file.
+
+### Specs & plans (`specs/`, `plans/`, `docs/**/plans/`)
+
+| Situation | Verdict | Confidence |
+|---|---|---|
+| Path referenced by a `complete`/`abandoned` triage | stale — the work it described is over | **high** |
+| *Filename* matches a reference, but not the path | stale, but the match is a guess | medium |
+| Referenced by any non-finished triage | not a candidate — live work | — |
+| No triage reference AND older than `--orphan-age` (default 30d) | **flag only** — possible abandoned scaffolding | low |
+| Plain `docs/` file with no triage link | not a candidate — treated as permanent | — |
+
+The filename-only row exists because `specs/sso.md` and `docs/archive/sso.md` share a basename: that match can be right, but it must never reach the high-confidence set Phase 5 offers by default. Protection works the other way — *any* match strength against a live triage protects the file, since a wrongly-protected file costs nothing and a wrongly-deleted one is gone.
+
+`git-merged` is a *third* signal you layer on in Phase 3 — a spec/plan whose work already landed on the main branch is strong evidence it's safe to delete, even when the triage status didn't say so.
+
+---
+
+## Phase 1 — Resolve scope & scan
+
+Find where triage records live, then scan. Reuse the triage plugin's path resolver so cleanup reads from exactly the same place triage writes:
+
+```bash
+TRIAGE_DIR="$(node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" \
+  --root "$(pwd)" --home "$HOME" --path-only)"
+```
+
+If `TRIAGE_DIR` is empty, persistence is unconfigured — there are no triage records to clean. Say so and continue to the spec/plan scan anyway (those can still exist).
+
+Run the scan. Pass today's date explicitly — the script does age math against it and stays deterministic. Pass `--triage-dir "$TRIAGE_DIR"` unconditionally: the scanner treats an empty value as "no triage records configured" and still scans `specs/`/`plans/`. (Avoid conditional shell expansions like `${TRIAGE_DIR:+...}` here — they collapse the flag and its value into one argument under some shells and the scan errors out.)
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage-cleanup/scripts/scan-stale.mjs" \
+  --root "$(pwd)" \
+  --now "$(date +%F)" \
+  --triage-dir "$TRIAGE_DIR"
+```
+
+The script emits one JSON object: `{ summary, candidates[], active[] }`. Each candidate carries `kind` (`triage`/`spec`/`plan`/`doc`), `path`, `reason`, `confidence`, `flagOnly`, `ageDays` (record age), `touchedDays` + `ageSource` (last change, and where that date came from), and `needsRepair` on records whose `status` or `created` field breaks the schema. `summary.needsRepair` counts those across both candidates and active records. On non-zero exit, surface the stderr line and halt — a broken scan must not degrade into hand-rolled `ls`/`find` over the triage dir.
+
+Honor user scope hints from `$ARGUMENTS` by passing the matching flag, e.g. "only drafts" → still scan all, but in Phase 4 present only `kind: triage` draft candidates; "anything older than 90 days" → `--draft-age 90 --orphan-age 90`.
+
+---
+
+## Phase 2 — Locate spec/plan artifacts (only if needed)
+
+`scan-stale.mjs` already scans `specs/`, `plans/`, and `docs/` under the project root. If the scan found **zero** spec/plan candidates *and* none of those directories exist, the project may keep plans somewhere else. Ask before assuming there's nothing to clean:
+
+Use AskUserQuestion: "I didn't find a `specs/`, `plans/`, or `docs/` directory. Where do this project's specs and implementation plans live?" Offer a couple of likely paths and an "elsewhere / none" option. If the user names a directory, re-run the scan with `--dir "<abs-path>"` (repeatable) added.
+
+Skip this phase entirely when the default directories exist or candidates were already found — don't interrupt the user to confirm what the scan already saw.
+
+---
+
+## Phase 3 — Git-merged enrichment (optional, when in a git repo)
+
+For **spec/plan** candidates, a strong independent signal that the work is over is that the file already landed on the main branch. Unlike commit *dates* — which the scanner reads, because they're a plain fact — merge detection is judgment: branch naming and squash-merges vary. That's why it lives here rather than in the scanner.
+
+If `git rev-parse --is-inside-work-tree` succeeds, for each spec/plan candidate check whether it exists on the main branch and is unchanged there:
+
+```bash
+git ls-tree -r --name-only main -- "<relpath>"   # present on main?
+git diff --quiet main -- "<relpath>"             # identical to main? (exit 0 = yes)
+```
+
+Pick the actual default branch (`main`, `master`, `develop` — check `git remote show origin` or the repo's convention) rather than hardcoding. Treat "present and identical on the default branch" as upgrading a low-confidence orphan to a confident delete, and note it in the report ("already merged to `main`"). Never let a *missing* git repo block cleanup — this phase is additive.
+
+---
+
+## Phase 4 — Present the report
+
+Translate the JSON into a clear, skimmable summary. Lead with the safe deletes, separate the judgment calls, and make recoverability explicit.
+
+```text
+## Triage Cleanup — <N> candidate(s)
+
+### Safe to delete (high confidence)
+- [triage] add-sso-login.yaml — complete, all phases finished
+- [spec]   specs/sso-login.md — referenced by complete triage add-sso-login
+- [plan]   plans/sso-rollout.md — already merged to main
+
+### Worth a look (medium)
+- [triage] old-refactor.draft.yaml — stale draft, 47d old, never confirmed
+
+### Flagged, not auto-included (low) — I won't delete these unless you pick them
+- [triage] half-done-feature.yaml — in_progress, 80d untouched, may still be real work
+- [spec]   14 orphaned specs in specs/, 91–118d old — no triage references them (say "list them" for the full set)
+
+### Needs repair, not deletion (`needsRepair`)
+- [triage] permission-checking-backend.yaml — off-schema status "implementation_complete"
+- [triage] mobile-permissions-p5.yaml — date in `created_at`, schema field is `created`
+
+⚠️ Not under git: <list any untracked targets> — deleting these is unrecoverable.
+```
+
+**Collapse long groups.** Beyond ~8 items of the same kind and reason, show a count, the directory, and the age range instead of every filename — an unreadable 60-line list is a report nobody acts on. Keep the full list one request away.
+
+**`needsRepair` records get their own section, not the delete list.** These are lifecycle breakage, not finished work, and a mislabelled record is often live work — never present one as "likely dead". Run the validator to name the exact violation, and report it. This skill has no write tools, so repairing the record is the user's call (or the `triage` skill's):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/validate-record.mjs" --file "<abs path>"
+```
+
+Only offer deletion for these if the user confirms the work itself is over.
+
+Before showing the warning line, check which targets git is tracking (`git ls-files --error-unmatch "<path>"` exits 0 if tracked). Untracked files have no git history to restore from, so call them out loudly — that's the difference between a reversible cleanup and permanent loss.
+
+If there are zero candidates, say the triage area is clean and stop. Don't manufacture work.
+
+---
+
+## Phase 5 — Confirmation gate
+
+Deletion only proceeds on explicit approval. Ask plainly, e.g.: "Delete the high-confidence items? You can also say 'include the drafts', name specific files, or 'all of them'."
+
+Rules for building the final delete list:
+
+- **flag-only** candidates (low confidence) are excluded by default. Include one only if the user names it or explicitly says to include the low-confidence/flagged group.
+- Default the offer to the high-confidence set; let the user widen or narrow it.
+- If the user says nothing actionable, or hesitates, do **not** delete. A skipped cleanup is always safe; a wrong delete is not.
+- Echo the exact files about to be deleted one more time if the list includes anything untracked by git.
+
+---
+
+## Phase 6 — Delete
+
+Hand the approved list to the jailed executor. Pass every directory the targets legitimately live in as an `--allow-root`, so the script can refuse anything that slipped outside (the triage dir plus `specs`/`plans`/`docs` or any user-named dir from Phase 2):
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage-cleanup/scripts/delete-targets.mjs" \
+  --allow-root "$TRIAGE_DIR" \
+  --allow-root "$(pwd)/specs" --allow-root "$(pwd)/plans" --allow-root "$(pwd)/docs" \
+  --target "<abs path>" --target "<abs path>"
+```
+
+Run it once with `--dry-run` first if the list is large or includes untracked files — the output names exactly what would go. Then run for real. The script aborts the whole batch (exit 2, nothing deleted) if any target escapes the allow-roots or is a directory; surface that diagnostic rather than working around it.
+
+Report the result from the script's JSON: what was deleted, what was skipped (e.g. already gone), and remind the user that git-tracked deletions are recoverable via `git restore` / `git checkout` until committed.
+
+---
+
+## Constraints
+
+- **Never delete without an explicit, post-report confirmation.** Report-then-confirm is the whole safety model; do not collapse it.
+- **Never auto-include flag-only / low-confidence candidates.** They require the user to pick them by name.
+- **Never read or delete the triage dir directly** with inline `ls`/`find`/`rm`. Scanning goes through `scan-stale.mjs`; deletion goes through `delete-targets.mjs` with its jail.
+- **Never widen the jail** to cover paths the user didn't intend. Allow-roots are the artifact directories only.
+- Works on projects with no `.claude/triage/` (nothing to scan → say so) and outside git (skip Phase 3, warn that everything is unrecoverable).
+- Halt and surface diagnostics on any non-zero script exit; never fall back to hand-rolled file operations the scripts exist to prevent.
+- This skill never edits triage record contents — its only mutation is deletion of whole stale files the user approved. To change a record's status instead of deleting it, that's the `triage` skill's job.

--- a/plugins/triage/skills/triage-cleanup/scripts/delete-targets.mjs
+++ b/plugins/triage/skills/triage-cleanup/scripts/delete-targets.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// Serves: triage-cleanup SKILL.md — Phase 6 confirmed deletion.
+// Safely deletes a confirmed list of stale artifacts. The skill body decides WHAT to delete
+// (after the user confirms); this script enforces that nothing outside the allowed roots is touched.
+//
+// Safety model — fail closed:
+//   * Every target must resolve inside one of the --allow-root jails, or the whole batch aborts
+//     (exit 2) having deleted nothing. One bad path never gets a partial delete.
+//   * --dry-run reports what would happen and touches nothing.
+//   * Only regular files are removed; a target that is a directory aborts the batch.
+//
+// Inputs (argv):
+//   --allow-root <abs>   required, repeatable — a directory targets must live under (triage dir, specs/, ...).
+//   --target <abs>       repeatable — a file to delete.
+//   --manifest <abs>     optional — JSON file: ["<abs>", ...] or {"targets":["<abs>", ...]}.
+//   --dry-run            report only; delete nothing.
+// stdout: a single JSON object {deleted, wouldDelete, skipped}. Exit 0 on success;
+//         exit 2 + stderr on bad argv or a jail/type violation (nothing deleted).
+import { statSync, readFileSync, rmSync } from "node:fs";
+import { isAbsolute, resolve, sep } from "node:path";
+
+function die(msg) { process.stderr.write(`delete-targets: ${msg}\n`); process.exit(2); }
+
+const argv = process.argv.slice(2);
+const allowRoots = [];
+const targets = [];
+let manifest = "", dryRun = false;
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  const next = () => { if (i + 1 >= argv.length) die(`${a} requires a value`); return argv[++i]; };
+  if (a === "--allow-root") allowRoots.push(next());
+  else if (a === "--target") targets.push(next());
+  else if (a === "--manifest") manifest = next();
+  else if (a === "--dry-run") dryRun = true;
+  else die(`unknown arg: ${a}`);
+}
+if (allowRoots.length === 0) die("at least one --allow-root is required");
+for (const r of allowRoots) if (!isAbsolute(r)) die(`--allow-root must be absolute: ${r}`);
+
+if (manifest) {
+  if (!isAbsolute(manifest)) die(`--manifest must be absolute: ${manifest}`);
+  let parsed;
+  try { parsed = JSON.parse(readFileSync(manifest, "utf8")); }
+  catch (e) { die(`cannot read/parse manifest: ${e.message}`); }
+  const list = Array.isArray(parsed) ? parsed : parsed?.targets;
+  if (!Array.isArray(list)) die("manifest must be a JSON array or {\"targets\":[...]}");
+  targets.push(...list);
+}
+if (targets.length === 0) die("no targets given (use --target or --manifest)");
+
+const roots = allowRoots.map((r) => resolve(r));
+function inJail(p) {
+  return roots.some((r) => p === r || p.startsWith(r + sep));
+}
+
+// Validation pass — fail closed before any deletion.
+const resolved = [];
+for (const t of targets) {
+  if (!isAbsolute(t)) die(`target must be absolute: ${t}`);
+  const r = resolve(t);
+  if (!inJail(r)) die(`target escapes all --allow-root jails: ${t}`);
+  let st = null;
+  try { st = statSync(r); } catch { st = null; }
+  if (st && st.isDirectory()) die(`target is a directory, refusing: ${t}`);
+  resolved.push({ path: r, exists: !!st });
+}
+
+// Action pass.
+const deleted = [], wouldDelete = [], skipped = [];
+for (const { path, exists } of resolved) {
+  if (!exists) { skipped.push({ path, reason: "not found" }); continue; }
+  if (dryRun) { wouldDelete.push(path); continue; }
+  try { rmSync(path); deleted.push(path); }
+  catch (e) { skipped.push({ path, reason: e.message }); }
+}
+
+process.stdout.write(`${JSON.stringify({ dryRun, deleted, wouldDelete, skipped })}\n`);

--- a/plugins/triage/skills/triage-cleanup/scripts/scan-stale.mjs
+++ b/plugins/triage/skills/triage-cleanup/scripts/scan-stale.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+// Serves: triage-cleanup SKILL.md — Phase 1/2 stale-candidate classification.
+// Deterministic classifier: reads triage YAMLs + discovers spec/plan/doc artifacts,
+// then labels each as a stale deletion candidate (with confidence) or active.
+// Does NO deletion — that is delete-targets.mjs.
+//
+// It DOES ask git for one thing: each file's last-commit date. That is a deterministic
+// fact and it is the only correct answer available — mtime is stamped at checkout, so on
+// a fresh clone every artifact reports the same bogus age (measured: 61 specs spanning
+// three weeks all reported "75d"). Merge-detection stays in the skill body, where the
+// heuristic parts of git (branch naming, squash merges) belong.
+//
+// Inputs (argv):
+//   --root <abs>            required — project root (for spec/plan/doc discovery + note refs).
+//   --now <YYYY-MM-DD>      required — today's date, injected for deterministic age math.
+//   --triage-dir <abs>      optional — resolved triage dir; omit/none if persistence is unconfigured.
+//   --dir <abs>             optional, repeatable — extra artifact dir to scan (e.g. user-named plans path).
+//   --draft-age <days>      optional — drafts older than this are stale (default 30).
+//   --inprogress-age <days> optional — in_progress untouched longer than this is flagged (default 60).
+//   --orphan-age <days>     optional — unreferenced spec/plan older than this is flagged (default 30).
+// stdout: a single JSON object (see SHAPE below). Exit 0 on success; exit 2 + stderr on bad argv.
+import { statSync, readdirSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { isAbsolute, join, basename, relative, dirname, sep } from "node:path";
+import { yamlField, phaseStatuses, recordCreated, phaseIsDone, TRIAGE_STATUSES } from "../../triage/scripts/yaml-fields.mjs";
+
+function die(msg) { process.stderr.write(`scan-stale: ${msg}\n`); process.exit(2); }
+function isDir(p) { try { return statSync(p).isDirectory(); } catch { return false; } }
+
+const argv = process.argv.slice(2);
+let root = "", now = "", triageDir = "";
+const extraDirs = [];
+let draftAge = 30, inProgressAge = 60, orphanAge = 30;
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  const next = () => { if (i + 1 >= argv.length) die(`${a} requires a value`); return argv[++i]; };
+  if (a === "--root") root = next();
+  else if (a === "--now") now = next();
+  else if (a === "--triage-dir") triageDir = next();
+  else if (a === "--dir") extraDirs.push(next());
+  else if (a === "--draft-age") draftAge = Number(next());
+  else if (a === "--inprogress-age") inProgressAge = Number(next());
+  else if (a === "--orphan-age") orphanAge = Number(next());
+  else die(`unknown arg: ${a}`);
+}
+if (!root) die("--root is required");
+if (!isAbsolute(root)) die(`--root must be absolute: ${root}`);
+if (!now) die("--now is required");
+const nowMs = Date.parse(`${now}T00:00:00Z`);
+if (Number.isNaN(nowMs)) die(`--now must be YYYY-MM-DD: ${now}`);
+if (triageDir && !isAbsolute(triageDir)) die(`--triage-dir must be absolute: ${triageDir}`);
+for (const d of extraDirs) if (!isAbsolute(d)) die(`--dir must be absolute: ${d}`);
+for (const [name, v] of [["--draft-age", draftAge], ["--inprogress-age", inProgressAge], ["--orphan-age", orphanAge]]) {
+  if (!Number.isFinite(v) || v < 0) die(`${name} must be a non-negative number`);
+}
+
+// ---- helpers -------------------------------------------------------------
+
+// Artifact paths referenced anywhere in the record (notes, etc.): specs|plans|docs/...md.
+function referencedPaths(content) {
+  return [...content.matchAll(/(?:specs|plans|docs)\/[^\s"'\]]+\.md/g)].map((m) => m[0]);
+}
+
+function ageDaysFrom(iso) {
+  const ms = Date.parse(`${iso}T00:00:00Z`);
+  if (Number.isNaN(ms)) return null;
+  return Math.floor((nowMs - ms) / 86_400_000);
+}
+
+// Clamp at 0: --now is midnight UTC but real timestamps fall later the same day, which
+// would otherwise report a fresh file as "-1d". A negative age is never meaningful here.
+const clamp = (d) => Math.max(0, d);
+
+function ageDaysFromMtime(p) {
+  return clamp(Math.floor((nowMs - statSync(p).mtimeMs) / 86_400_000));
+}
+
+// Last-commit date per file, one `git log` per directory group. Paths come back relative
+// to the -C directory thanks to --relative, so they key straight back to our inputs.
+// Any failure (not a repo, git missing, never-committed files) leaves the map empty and
+// callers fall back to mtime — which is honest for untracked files, since nothing else knows.
+function gitDates(dir, relPaths) {
+  const out = new Map();
+  if (!relPaths.length || !isDir(dir)) return out;
+  try {
+    const log = execFileSync(
+      "git",
+      ["-C", dir, "log", "--format=%H %cs", "--name-only", "--relative", "--", ...relPaths],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], maxBuffer: 64 * 1024 * 1024 },
+    );
+    let date = "";
+    for (const line of log.split("\n")) {
+      if (!line) continue;
+      const m = line.match(/^[0-9a-f]{7,40} (\d{4}-\d{2}-\d{2})$/);
+      if (m) { date = m[1]; continue; }
+      if (!out.has(line)) out.set(line, date); // log is newest-first, so first hit wins
+    }
+  } catch { /* mtime fallback */ }
+  return out;
+}
+
+// How long since this file was last changed, and where that answer came from.
+function lastTouched(absPath, dir, gitMap) {
+  const d = gitMap.get(relative(dir, absPath));
+  if (d) {
+    const age = ageDaysFrom(d);
+    if (age !== null) return { ageDays: clamp(age), ageSource: "git" };
+  }
+  return { ageDays: ageDaysFromMtime(absPath), ageSource: "mtime" };
+}
+
+function baseSlug(file) {
+  return basename(file).replace(/\.yaml$/, "").replace(/\.draft$/, "").replace(/\.md$/, "");
+}
+
+// Classify a file path into an artifact kind by its path segments.
+// A `/plans/` segment wins (handles docs/**/plans/foo.md), then `/specs/`, else doc.
+function kindOf(file) {
+  const segs = relative(root, file).split(sep);
+  if (segs.includes("plans")) return "plan";
+  if (segs.includes("specs")) return "spec";
+  return "doc";
+}
+
+function walkMd(dir, out) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) walkMd(full, out);
+    else if (e.isFile() && e.name.endsWith(".md")) out.push(full);
+  }
+}
+
+// ---- triage records ------------------------------------------------------
+
+const candidates = [];
+const active = [];
+const doneRefs = new Set();   // artifact ref strings owned by complete/abandoned triages
+const liveRefs = new Set();   // artifact ref strings owned by draft/in_progress triages
+
+if (triageDir && isDir(triageDir)) {
+  const files = readdirSync(triageDir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith(".yaml"))
+    .map((e) => join(triageDir, e.name))
+    .sort();
+
+  const triageGit = gitDates(triageDir, files.map((f) => relative(triageDir, f)));
+
+  for (const file of files) {
+    const c = readFileSync(file, "utf8");
+    const status = yamlField(c, "status").trim();
+    const created = recordCreated(c);
+    const task = yamlField(c, "task").trim();
+    const createdAge = created ? ageDaysFrom(created) : null;
+    const touched = lastTouched(file, triageDir, triageGit);
+    const phases = phaseStatuses(c);
+    const allPhasesDone = phases.length > 0 && phases.every(phaseIsDone);
+    const refs = referencedPaths(c);
+    // A record whose date field is missing or unparseable can't be aged from its own
+    // contents; flagged so the report can point the user at validate-record.mjs.
+    const malformed = createdAge === null;
+    // Two ages, deliberately separate: `ageDays` is how old the record is, `touchedDays`
+    // is how long since anyone worked on it. The draft and in_progress rules need different ones.
+    const rec = {
+      kind: "triage", path: file, slug: baseSlug(file), status, created,
+      ageDays: createdAge, touchedDays: touched.ageDays, ageSource: touched.ageSource, malformed,
+    };
+
+    let verdict = null; // {reason, confidence, flagOnly}
+    if (status === "abandoned") {
+      verdict = { reason: "abandoned — explicitly given up", confidence: "high", flagOnly: false };
+    } else if (status === "complete") {
+      verdict = allPhasesDone
+        ? { reason: "complete — all phases finished", confidence: "high", flagOnly: false }
+        : { reason: "marked complete but phases unfinished", confidence: "medium", flagOnly: false };
+    } else if (status === "draft") {
+      // Drafts are judged on creation age — the rule is "never confirmed since it was
+      // written". Fall back to file age when the record didn't record its own date.
+      const age = createdAge ?? touched.ageDays;
+      if (age > draftAge) {
+        verdict = { reason: `stale draft — ${age}d old, never confirmed`, confidence: "medium", flagOnly: false };
+      }
+    } else if (status === "in_progress") {
+      // In-progress work is judged on *last touched*, per the documented rule. Creation
+      // age would flag long-running-but-active work as dead.
+      if (touched.ageDays > inProgressAge) {
+        verdict = {
+          reason: `stale in_progress — ${touched.ageDays}d untouched (${touched.ageSource}), likely dead`,
+          confidence: "low", flagOnly: true,
+        };
+      }
+    } else if (!status) {
+      verdict = {
+        reason: "no status field — cannot be resumed or closed, invisible to the lifecycle",
+        confidence: "low", flagOnly: true,
+      };
+    } else {
+      // Off-schema status: not resumable by recall (--active matches draft|in_progress)
+      // and not closable by any rule above, so it would live forever unnoticed.
+      verdict = {
+        reason: `off-schema status "${status}" — expected ${TRIAGE_STATUSES.join("|")}`,
+        confidence: "low", flagOnly: true,
+      };
+    }
+
+    // A triage's referenced artifacts inherit its liveness for the file pass below.
+    // "Done" is tied to status (complete/abandoned) — not to our delete verdict — because the
+    // file-staleness rule is explicitly: a spec/plan is stale when its triage is complete/abandoned.
+    // Anything else (including off-schema) counts as live, so its specs stay protected.
+    const refTarget = status === "complete" || status === "abandoned" ? doneRefs : liveRefs;
+    for (const r of refs) refTarget.add(r);
+
+    // Schema breakage is not the same finding as finished work, and the right response is
+    // the opposite one: a record whose status or date field is wrong may be perfectly live
+    // work that was written badly, so it wants repairing, not deleting.
+    // Deliberately keyed on the schema's own field name, not on `recordCreated`'s tolerant
+    // read — a `created_at` record works here but still fails validate-record, and the two
+    // must reach the same verdict or the repair prompt never mentions it.
+    const needsRepair = malformed || !yamlField(c, "created").trim() || !status || !TRIAGE_STATUSES.includes(status);
+
+    if (verdict) candidates.push({ ...rec, ...verdict, needsRepair, referencedBy: null, task });
+    else active.push({ ...rec, task, needsRepair, reason: `active (${status})` });
+  }
+}
+
+// ---- spec / plan / doc artifacts ----------------------------------------
+
+const scanDirs = [join(root, "specs"), join(root, "plans"), join(root, "docs"), ...extraDirs];
+const seen = new Set();
+const mdFiles = [];
+for (const d of scanDirs) {
+  if (!isDir(d)) continue;
+  const found = [];
+  walkMd(d, found);
+  for (const f of found) if (!seen.has(f)) { seen.add(f); mdFiles.push(f); }
+}
+mdFiles.sort();
+
+// Group by the directory we can ask git about: files under root go through root, extra
+// dirs are asked separately since they may live in another repo (or none).
+const fileGit = new Map(); // absPath -> {ageDays, ageSource}
+const groups = new Map();
+for (const f of mdFiles) {
+  const base = f.startsWith(root + sep) ? root : (extraDirs.find((d) => f.startsWith(d + sep)) ?? dirname(f));
+  if (!groups.has(base)) groups.set(base, []);
+  groups.get(base).push(f);
+}
+for (const [base, files] of groups) {
+  const gm = gitDates(base, files.map((f) => relative(base, f)));
+  for (const f of files) fileGit.set(f, lastTouched(f, base, gm));
+}
+
+// Reference match strength: an exact relative-path match is proof; a bare filename match
+// is a guess that can collide across directories (specs/foo.md vs docs/archive/foo.md),
+// so it must never reach the high-confidence set that Phase 5 offers by default.
+function refMatch(file, refSet) {
+  const rel = relative(root, file);
+  const base = basename(file);
+  let weak = false;
+  for (const r of refSet) {
+    if (r === rel) return "path";
+    if (basename(r) === base) weak = true;
+  }
+  return weak ? "basename" : null;
+}
+
+for (const file of mdFiles) {
+  const kind = kindOf(file);
+  const slug = baseSlug(file);
+  const rel = relative(root, file);
+  const doneMatch = refMatch(file, doneRefs);
+  const liveMatch = refMatch(file, liveRefs);
+  const touched = fileGit.get(file) ?? { ageDays: ageDaysFromMtime(file), ageSource: "mtime" };
+  // For a file artifact the two ages are the same thing — it has no recorded creation date.
+  const rec = {
+    kind, path: file, slug, status: null, created: null,
+    ageDays: touched.ageDays, touchedDays: touched.ageDays, ageSource: touched.ageSource,
+  };
+
+  // Protection wins on either match strength — a false protect costs nothing, a false
+  // delete is unrecoverable.
+  if (liveMatch) {
+    active.push({ ...rec, reason: "referenced by an active (draft/in_progress) triage" });
+    continue;
+  }
+  if (doneMatch === "path") {
+    candidates.push({ ...rec, reason: "referenced by a complete/abandoned triage — work is over", confidence: "high", flagOnly: false, referencedBy: rel });
+    continue;
+  }
+  if (doneMatch === "basename") {
+    candidates.push({ ...rec, reason: "filename matches a reference in a complete/abandoned triage, but not its path — verify before deleting", confidence: "medium", flagOnly: false, referencedBy: rel });
+    continue;
+  }
+  // Unreferenced. Orphan-staleness applies only to work artifacts (specs/plans), never plain docs.
+  if (kind === "doc") {
+    active.push({ ...rec, reason: "doc with no triage reference — treated as permanent, not a candidate" });
+    continue;
+  }
+  if (touched.ageDays > orphanAge) {
+    candidates.push({ ...rec, reason: `orphaned ${kind} — no triage reference, ${touched.ageDays}d old (${touched.ageSource})`, confidence: "low", flagOnly: true, referencedBy: null });
+  } else {
+    active.push({ ...rec, reason: `unreferenced ${kind} but recent (${touched.ageDays}d) — left alone` });
+  }
+}
+
+// ---- output --------------------------------------------------------------
+
+const byKind = {};
+const byConfidence = { high: 0, medium: 0, low: 0 };
+for (const c of candidates) {
+  byKind[c.kind] = (byKind[c.kind] || 0) + 1;
+  byConfidence[c.confidence] = (byConfidence[c.confidence] || 0) + 1;
+}
+
+const report = {
+  now,
+  root,
+  triageDir: triageDir || null,
+  thresholds: { draftAge, inProgressAge, orphanAge },
+  summary: {
+    candidates: candidates.length,
+    autoDeletable: candidates.filter((c) => !c.flagOnly).length,
+    flagOnly: candidates.filter((c) => c.flagOnly).length,
+    needsRepair: candidates.filter((c) => c.needsRepair).length + active.filter((a) => a.needsRepair).length,
+    byConfidence,
+    byKind,
+  },
+  candidates,
+  active,
+};
+
+process.stdout.write(`${JSON.stringify(report)}\n`);

--- a/plugins/triage/skills/triage/SKILL.md
+++ b/plugins/triage/skills/triage/SKILL.md
@@ -166,20 +166,13 @@ For each phase in the derived flow, find the **best-matching skill or agent** fr
 
 ### Second pass — Tool-shaped supporting skills
 
-Some skills aren't phase-shaped. They're tools that augment whichever phase the user is in: a code-structure search skill speeds up Exploration, Debugging, and Implementation alike; a library-docs lookup fires whenever the task touches a named framework. After the per-phase mapping above, run a second pass against the same candidate list using these intent signals:
+Some candidates aren't phase-shaped: they're tools that augment whichever phase the
+user is in (code-structure search, library-docs lookup, memory recall, MCP servers).
+Run a second pass for these and surface matches in the **Supporting Skills** block.
 
-| Tool shape | Match on descriptions mentioning… |
-|---|---|
-| **Code understanding** | code structure search, AST traversal, symbol lookup, "instead of reading full files", structural code exploration, tree-sitter |
-| **Library docs** | library/framework/SDK documentation, API syntax lookup, version migration, library-specific debugging, "use when user asks about <lib>" |
-| **Memory recall** | persistent cross-session memory, prior-session lookup, "did we solve this before", cross-session search |
-| **MCP server** | any discovered `kind: "mcp-server"` record — match the server **name** (and `description` when present) to the shape it serves: docs servers (e.g. context7) → Library docs; memory servers (e.g. claude-mem) → Memory recall; code-graph/review servers (e.g. code-review-graph) → Code understanding / Review |
-
-**MCP servers are discovered, not assumed.** `discover-skills.mjs` emits `kind: "mcp-server"` records from the project `.mcp.json`, the user's `~/.claude.json` (this project's entry), and any installed plugin's `.mcp.json`. A server shipped by a plugin — e.g. a `code-review-graph` plugin — is therefore surfaced automatically with no plugin-specific knowledge baked into this skill. **Limitation:** discovery is server-level. The candidate record carries the server's name and (when the config provides one) its description — not its individual tool schemas, which are only available at runtime. Surface the server in the **Supporting Skills** block by name; do not claim specific tools it may expose.
-
-Surface every match in the recommendation's **Supporting Skills** block. Tool-shaped skills are not part of the phase sequence — they don't get tie-broken against phase matches and they don't get the generic-prompt fallback (if no tool-shaped skill matches a given shape, simply omit that shape from the block).
-
-For each match, write a one-sentence trigger condition tailored to *this task* (e.g., "fires when locating the existing auth middleware before editing it" — not the skill's generic description).
+Read `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/tool-shaped-skills.md` for the
+shape table, the MCP discovery rules, and how matches are written up. Skip it when
+no candidate looks tool-shaped.
 
 ---
 
@@ -237,49 +230,16 @@ Mixed Features should almost always be Medium — the whole point of the classif
 
 ## Phase 6 — Persist the Triage Record
 
-Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`. This is how cross-session retrieval works — a future session invokes `triage-recall.mjs` (Phase 1a) and finds the record that this phase wrote.
+Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`.
+That is how cross-session retrieval works — a future session finds it via Phase 1a.
 
-### When to fire Phase 6
+Fires automatically after Phase 5 on **high** confidence; on medium/low, wait for the
+user to pick an interpretation first. It is skipped silently when the project has no
+configured storage path.
 
-- **High confidence** → fire automatically, immediately after Phase 5 output. Write with `status: draft` and the filename suffix `.draft.yaml`. The draft exists so nothing is lost if the user walks away; it's explicitly marked so it doesn't pollute `--active` results as a decided plan.
-- **Medium / Low confidence** → wait for the user to pick an interpretation (from the "If I Misclassified" block or the two-interpretation surface), then fire with `status: draft`.
-
-### Confirmation gate (promotes draft → in_progress)
-
-After the draft is written, tell the user:
-
-> `Saved as draft at <path>. Say "confirmed" (or start running the first recommended command) to promote to in_progress.`
-
-On confirmation — or when the user's next message clearly proceeds with the flow (e.g., invoking the first recommended skill) — rename `<slug>.draft.yaml` → `<slug>.yaml` and flip `status: draft` → `status: in_progress`. This two-step design prevents the old "user skipped confirmation ⇒ nothing saved" leak while keeping drafts distinguishable in git diffs and in recall.
-
-### Resolving the storage path
-
-```bash
-node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" --root "$(pwd)" --home "$HOME"
-```
-
-Contract: stdout JSON, one of:
-
-- `{"path":"<abs>","scope":"project"}` — preferred; versioned with the project. If the directory doesn't exist yet, create it with `mkdir -p` before writing.
-- `{"path":"<abs>","scope":"user"}` — fallback when the project has no `.claude/` dir.
-- `{"path":null,"scope":null}` — nothing configured; **skip Phase 6 silently**. Do not attempt to create `.claude/` in the project — that's a project-config decision, not a triage decision.
-
-Non-zero + stderr on missing/relative `--root` or `--home`. Halt on non-zero and surface the diagnostic.
-
-### Slug derivation
-
-- Lowercase, hyphen-separated, max 50 chars, stripped of punctuation.
-- If `<slug>.yaml` or `<slug>.draft.yaml` already exists for an unrelated task, append `-2`, `-3`, etc.
-
-### File contents
-
-Write the file using the schema in `references/triage-schema.md` — that document is the source of truth for fields, lifecycle states, and invariants. Read it before writing.
-
-### After writing
-
-- Output the exact first command to copy-paste and stop.
-- Do not begin implementation.
-- Do not add an entry to MEMORY.md — the triage directory is the index, reached through `triage-recall.mjs`.
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/phase6-persistence.md`
+for the confirmation gate, path resolution, and slug rules — and
+`references/triage-schema.md` for the fields themselves.
 
 ---
 

--- a/plugins/triage/skills/triage/SKILL.md
+++ b/plugins/triage/skills/triage/SKILL.md
@@ -11,160 +11,98 @@ argument-hint: "[task description in natural language]"
 
 # Triage Skill
 
-Advisory classifier — reads the user's configured skills/agents, classifies the task into a workflow shape, then maps each phase of that shape to the best-matching invocation available in the current environment. Never dispatches agents. Never begins implementation.
+Advisory classifier — reads the user's *actually installed* skills, agents, and MCP servers, works out what shape of work the task is, and maps each phase of that shape to the best available invocation. Never dispatches agents. Never begins implementation.
 
-## Core Concept
+## Core concept
 
-Triage is a **two-step translator**, not a hardcoded routing table:
+Triage is a two-step translator, not a routing table:
 
-1. **Classification → Abstract phase sequence** (a universal workflow shape: Exploration, Planning, Implementation, Debugging, Fix, Design Work, Review)
-2. **Abstract phases → Concrete invocations** (dynamically matched from whatever skills and agents the user actually has)
+1. Task description → an abstract phase sequence (the kind of thinking the work needs).
+2. Abstract phases → concrete invocations, matched from whatever is installed right now.
 
-This SKILL.md never names specific downstream skills. A skill whose description talks about exploring intent and requirements is a candidate for the Exploration phase. A skill whose description mentions writing an implementation plan, decomposing work, or authoring a spec is a candidate for Planning. The mapping is computed each invocation from whatever is currently discovered — not baked into this prompt. If no skill matches a phase, triage emits a **generic prompt fallback** — a copy-pasteable instruction the user can run directly.
+**This file never names a downstream skill.** The candidate list is discovered on every invocation, so the same triage works with any plugin set, any bespoke team workflow, or none at all. When nothing matches a phase, emit a copy-pasteable generic prompt instead.
 
-The goal: the same triage skill produces sensible recommendations regardless of which skill packages, plugin namespaces, or bespoke team workflows the user has installed — or whether they have none at all.
-
-**Persistence model:** each triage is recorded as a YAML file at `.claude/triage/<slug>.yaml` (or user-global fallback), making triage decisions **versioned project artifacts** — visible in PR review, survivable across machines, and retrievable by future sessions via a deterministic script.
+Each triage is recorded as a YAML file under `.claude/triage/`, which makes the decision a versioned project artifact — reviewable in a PR and retrievable by a future session.
 
 ---
 
-## Phase 1 — Context & Config Discovery
+## Phase 1 — Discovery
 
-If `$ARGUMENTS` is empty, ask "What are you trying to do?" before proceeding. Otherwise treat `$ARGUMENTS` as the task description.
+If `$ARGUMENTS` is empty, ask "What are you trying to do?" first. Otherwise treat it as the task description.
 
-### 1a. Check for active triages (short-circuit on match)
-
-Before anything else, look for an existing triage on this same task so we don't duplicate planning across sessions:
+### 1a. Resume an existing triage?
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/triage-recall.mjs" \
   --dir "$(node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" --root "$(pwd)" --home "$HOME" --path-only)" \
-  --find "<2-4 key words from the task description>" \
-  --json
+  --find "<2-4 key words from the task>" --json
 ```
 
-If `triage-recall.mjs` returns a record whose `task` is a strong semantic match for `$ARGUMENTS`:
+If a returned record's `task` is a strong semantic match, show it with its phase statuses and ask: resume, or start fresh? On resume, skip to the Phase 4 output and jump to the first `pending` phase. If the resolver returns `{"path":null}` there is nowhere to persist and nothing to recall — continue silently.
 
-- Show the existing record and its phase statuses to the user.
-- Ask: "This looks like the triage we ran on `<date>`. Resume it, or start a new one?"
-- If resume: skip to Phase 5, emit the existing record's Recommended Invocations, and jump to the first `pending` phase.
-- If new: continue to Phase 1b.
-
-If the resolve script returns `{"path":null}`, skip the active check silently — there's nowhere to persist, so there's nowhere to recall from either. Continue to Phase 1b.
-
-### 1b. Candidate list (offloaded)
-
-Invoke the discovery script to build the skills+agents candidate list across all three scopes:
+### 1b. Candidate list
 
 ```bash
 node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/discover-skills.mjs" "$(pwd)" "$HOME"
 ```
 
-`$(pwd)` is the current project root; `$HOME` is the user's home directory. Both must resolve to absolute paths. The script itself validates absoluteness and exits 2 on failure.
+Emits a JSON array of `{ scope, kind, name, description, path }` — `scope` ∈ `project-local` | `user-global` | `plugin-installed`, `kind` ∈ `skill` | `agent` | `mcp-server`. This is the sole source of truth for what's available; don't re-glob or re-parse frontmatter.
 
-The script emits a JSON array of `{ scope, kind, name, description, path }` on stdout, where:
+**On non-zero exit:** surface the stderr diagnostic and halt. Never fall back to inline traversal — a failed script means malformed frontmatter or a broken environment, and a silent fallback hides exactly the regression the script exists to expose (see `references/offload-scripts.md` §Exit codes).
 
-- `scope` ∈ `project-local` | `user-global` | `plugin-installed`
-- `kind` ∈ `skill` | `agent` | `mcp-server`
+### 1c. Open specs
 
-This array is the input to Phase 4's mapping. Do not re-glob, re-read SKILL.md frontmatter, or re-parse YAML in the skill body — the script is the single source of truth.
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/find-open-specs.mjs" --root "$(pwd)"
+```
 
-**On non-zero exit:** surface the script's stderr diagnostic to the user and halt. Do not fall back to inline traversal — a failed script means the frontmatter is malformed or the environment is broken, and silent fallback would mask the regression the offload was meant to expose (see `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/offload-scripts.md` §Exit codes).
-
-### 1c. Context reads (inline)
-
-These are not globs and stay in the skill body. Read in this order and stop at the first missing item for project-specific reads; always read the user-global entry:
-
-1. `CLAUDE.md` at project root — project type, stack, conventions, mentioned skills.
-2. Open specs — invoke the script and consume its JSON:
-
-   ```bash
-   node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/find-open-specs.mjs" --root "$(pwd)"
-   ```
-
-   Contract: stdout JSON array of `{"slug": "<basename-minus-md>", "path": "<abs-path>"}`; empty array if `specs/` is missing. Non-zero + stderr on missing/relative `--root`. Halt and surface the diagnostic on non-zero; do not fall back to inline globbing.
-
-3. `git log --oneline -5` — active area of codebase.
-4. `~/.claude/CLAUDE.md` — user-global instructions (always read).
-
-Project-local items stop on first miss: if no `CLAUDE.md` exists, skip straight to the user-global read; the candidate list from 1b still provides project-local skills and agents if they exist.
+Returns `[{"slug", "path"}]`, empty when there is no `specs/`. Halt on non-zero. If a spec matches the described task, note that Implementation can run directly against it.
 
 ---
 
-## Phase 2 — Classify
+## Phase 2 — Classify and derive the flow
 
-Map the task description to exactly one type:
+Pick the classification that fits, then derive the phase sequence from the work itself — creative and restructuring work needs intent and constraints settled before code (Exploration → Planning → Implementation → Review); a bug needs the cause found before the patch (Debugging → Fix → Review); design work adds a Design Work phase before planning; a review request is just Review.
 
-| Classification | Signals |
+| Classification | Distinguishing signal |
 |---|---|
-| **UI Feature** | New page, component, significant template change, layout/interaction work with no significant data layer change |
-| **Logic Feature** | New service, store, data layer, API integration, background job — no significant UI |
-| **Mixed Feature** | New data flow AND new/modified UI to display it |
-| **Bug Fix** | Something broken, unexpected behavior, regression, error message, flaky test |
-| **Refactor** | Restructuring existing code without behavior change |
-| **Design** | UI/visual design work only — design tokens, component library authorship, mockups, Figma files. Requirements/intent exploration for a Feature is NOT Design — that's the Exploration phase of a Feature. |
-| **Review** | Code or UX review of existing/completed work |
-| **Other** | Doesn't fit above → ask one clarifying question, don't guess |
+| **UI Feature** | New page/component/layout; no significant data-layer change |
+| **Logic Feature** | New service, store, API integration, job; no significant UI |
+| **Mixed Feature** | New data flow *and* new UI to surface it |
+| **Bug Fix** | Broken, regressed, or flaky behavior |
+| **Refactor** | Restructuring with no behavior change |
+| **Design** | Visual/design-system work only — requirements exploration for a feature is *not* Design |
+| **Review** | Review of existing work |
+| **Other** | Ask one clarifying question; don't guess |
 
-**Ambiguity signals to flag before classifying:**
+Two signals worth flagging explicitly, because they change the work and are easy to miss:
 
-- Description mixes UI terms and logic/service terms → consider Mixed or ask
-- Bug touches components with mobile-framework prefixes (e.g., `ion-*`, `Native*`) → Bug Fix, note possible mobile-compat consideration
-- Requested refactor or feature touches a file referenced in an open spec → flag the conflict
+- A bug in components with mobile-framework prefixes (`ion-*`, `Native*`) may be a platform-compat issue, not app logic.
+- A task touching files covered by an unrelated open spec is a conflict the user should decide on.
+
+For trivially-scoped tasks (copy change, one-token swap) keep Exploration in the flow but mark it `(optional — scope is self-evident)`; never drop it silently, since "trivial" is exactly where hidden scope hides.
 
 ---
 
-## Phase 3 — Derive the Abstract Flow
+## Phase 3 — Map phases to invocations
 
-Every classification maps to a fixed sequence of **abstract phases**. Phases are conceptual — they describe the kind of thinking the work needs, not the command to run.
+For each phase, pick the best-matching candidate by the **intent** in its description, not by name substring:
 
-| Classification | Abstract Flow |
+| Phase | Descriptions mentioning… |
 |---|---|
-| UI / Logic / Mixed Feature | Exploration → Planning → Implementation → Review |
-| Refactor | Exploration → Planning → Implementation → Review |
-| Bug Fix | Debugging → Fix → Review |
-| Design | Exploration → Design Work → Planning → Implementation → Review |
-| Review | Review |
-| Other | (determined after clarification) |
-
-### Why Exploration is load-bearing for Features and Refactors
-
-Any creative work — creating features, building components, adding functionality, modifying behavior, or restructuring existing code — depends on first aligning on intent, constraints, prior art, and preferred patterns. This phase is not a ceremony; its absence means implementing the wrong thing or picking an idiom the project already rejected. For a refactor specifically, Exploration is where "ask about preferred patterns and prior art before proposing" lives.
-
-**Self-evident scope exception:** If the task is clearly trivial (copy change, single-token color swap, one-line bug-fix equivalent), still list Exploration but annotate it **`(optional — scope is self-evident)`** and explain that it's available as a sanity check if the user suspects hidden scope. Never silently drop it.
-
----
-
-## Phase 4 — Map Abstract Phases to Concrete Invocations
-
-For each phase in the derived flow, find the **best-matching skill or agent** from the candidate list built in Phase 1b. Match by the **intent** expressed in the skill's description — not by literal substring match on skill names.
-
-**Intent signals per abstract phase:**
-
-| Phase | Match on descriptions mentioning… |
-|---|---|
-| **Exploration** | brainstorm, intent, requirements, scope, options, pre-implementation, stress-test, poking holes, pressure-test, adversarial review of a spec |
-| **Planning** | writing plan, spec author, decomposition, phased implementation plan, sprint plan, roadmap, user story with acceptance criteria |
-| **Implementation** | executing a plan, test-driven workflow, feature build, implement-from-spec, parallel subagent execution, code generation |
-| **Debugging** | systematic debugging, root cause, diagnose, bug investigation |
-| **Fix** | code edit, applied fix, regression patch (often this is "use direct editing tools" — no dedicated skill needed) |
-| **Design Work** | visual design, design tokens, component library authoring, mockups, UI produced from a design spec |
+| **Exploration** | brainstorm, intent, requirements, scope, options, pre-implementation, stress-test, pressure-test, adversarial spec review |
+| **Planning** | writing a plan, spec authoring, decomposition, phased plan, sprint plan, roadmap, acceptance criteria |
+| **Implementation** | executing a plan, test-driven workflow, implement-from-spec, parallel subagent execution |
+| **Debugging** | systematic debugging, root cause, diagnose, investigation |
+| **Fix** | code edit, applied fix, regression patch — often just "use the editing tools directly" |
+| **Design Work** | visual design, design tokens, component library authoring, mockups, UI from a design spec |
 | **Review** | code review, PR review, standards check, verification before completion |
 
-**Tie-breaking** when multiple skills match the same phase:
+Ties break on: project-local over user-global over plugin-installed; then the description that names the workflow more precisely. If still tied, record **both** — one as `skill`, one as `alternative` — so the output shows the choice instead of hiding it.
 
-1. Prefer project-local skills (`.claude/skills/`) over user-global over plugin-installed
-2. Prefer skills whose description names the workflow context more precisely (a description that says "authors a phased implementation plan" is a stronger Planning match than one that only mentions "planning" in passing)
-3. If still ambiguous, record **both** — one as `skill`, the second as `alternative` — so the Phase 5 output can surface the tie-breaker visibly instead of silently dropping the loser
+No match for a phase → emit a generic prompt the user can paste, describing that phase's goal for *this* task in one or two sentences.
 
-**Fallback when no skill matches a phase** — emit a generic prompt the user can paste directly. The prompt should describe the phase's goal in one or two sentences and ask Claude to execute that phase specifically. Example scaffold (fill in the phase-specific part):
-
-> `No matching skill found for [Phase]. Paste this into Claude:`
-> `"[one-sentence description of what this phase should accomplish for the user's task]"`
-
-**Open specs:** If `specs/<slug>.md` matches the described task, add a note that Implementation can be invoked directly against the spec (in whatever way the mapped Implementation skill supports, or via a generic "implement specs/<slug>.md" prompt).
-
-### Second pass — Tool-shaped supporting skills
+### Second pass — tool-shaped supporting skills
 
 Some candidates aren't phase-shaped: they're tools that augment whichever phase the
 user is in (code-structure search, library-docs lookup, memory recall, MCP servers).
@@ -176,80 +114,62 @@ no candidate looks tool-shaped.
 
 ---
 
-## Phase 5 — Recommend
+## Phase 4 — Recommend
 
-For unambiguous tasks, output the recommendation immediately — no confirmation gate before display.
-For ambiguous tasks, ask exactly one clarifying question, then recommend.
-For low-confidence tasks, surface both plausible interpretations and ask the user to choose.
+Output immediately for unambiguous tasks. Ask exactly one clarifying question for ambiguous ones. When two readings are equally plausible, surface both and let the user choose.
 
-**Confidence calibration:**
-
-- **High** — task maps cleanly to one type with no meaningful alternative reading
-- **Medium** — classifiable but has meaningful alternative interpretations (e.g., Mixed Feature where it's unclear if the data layer already exists)
-- **Low** — two interpretations are roughly equally plausible → surface both, ask user to choose
-
-Mixed Features should almost always be Medium — the whole point of the classification is that it straddles concerns, and which layer to start from is a real choice.
-
-**Output format:**
+Confidence: **High** = one clean reading; **Medium** = real alternative interpretations; **Low** = two equally plausible readings. Mixed Features are almost always Medium — which layer to start from is a genuine choice.
 
 ```text
-## Task: [task description]
-**Classification:** [type]
-**Confidence:** High / Medium / Low
+## Task: [description]
+**Classification:** [type]   **Confidence:** High / Medium / Low
 
-### Abstract Flow
-[phase] → [phase] → [phase] → [phase]
+### Flow
+[phase] → [phase] → [phase]
 
 ### Recommended Invocations
-1. **[Phase]** — [mapped skill/agent invocation, or generic prompt fallback]
-   _Alternative: [secondary skill] — use if [one-sentence discriminator]_   ← only if tie-breaker produced one
-2. **[Phase]** — ...
-3. **[Phase]** — ...
-4. **[Phase]** — ...
+1. **[Phase]** — [invocation, or generic prompt fallback]
+   _Alternative: [skill] — use if [discriminator]_    ← only when a tie was recorded
+2. ...
 
-### Supporting Skills   ← omit entire section if no tool-shaped skills matched
-- **[skill]** — [one-sentence trigger condition for this task — when it would fire and what it would speed up]
-- **[skill]** — ...
+### Supporting Skills        ← omit when nothing matched
+- **[skill]** — [when it fires for this task]
 
 ### Why This Flow
-[1-2 sentences: classification reasoning + what makes these phases load-bearing for this task. Mention any flags from Phase 2 signals here.]
+[classification reasoning + any flagged signals, 1-2 sentences]
 
 ### If I Misclassified
-[alternative type] → [alternative flow summary with mapped invocations]
+[alternative type] → [alternative flow]
 ```
 
-**Flagging open specs:** If a matching open spec was found, add:
+Add `⚠️ Open spec: specs/<slug>.md — Implementation can run against this directly.` when Phase 1c found a match.
 
-```text
-⚠️ Open spec: specs/<slug>.md — Implementation can be run against this directly.
-```
-
-**No skills configured:** If Phase 1b discovered zero skills and zero agents, output only the abstract flow with a generic prompt for each phase. Keep it actionable — the user should be able to copy-paste any step into Claude and make progress.
+If discovery found zero skills and zero agents, output the flow with a generic prompt per phase — the user should still be able to paste any step and make progress.
 
 ---
 
-## Phase 6 — Persist the Triage Record
+## Phase 5 — Persist the record
 
 Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`.
 That is how cross-session retrieval works — a future session finds it via Phase 1a.
 
-Fires automatically after Phase 5 on **high** confidence; on medium/low, wait for the
-user to pick an interpretation first. It is skipped silently when the project has no
-configured storage path.
+Fires automatically after the Phase 4 output on **high** confidence; on medium/low, wait
+for the user to pick an interpretation first. It is skipped silently when the project has
+no configured storage path.
 
-Before writing, read `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/phase6-persistence.md`
-for the confirmation gate, path resolution, and slug rules — and
-`references/triage-schema.md` for the fields themselves.
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/skills/triage/references/phase5-persistence.md`
+for the confirmation gate, path resolution, slug rules, and the mandatory post-write
+validation — and `references/triage-schema.md` for the fields themselves.
 
 ---
 
 ## Constraints
 
-- Never dispatches agents or modifies source code files
-- Never hardcodes downstream skill names in this SKILL.md — concrete invocations are always derived from the user's current discovered config
-- Works on projects with zero `.claude/` config (graceful degradation via generic prompt fallbacks; Phase 6 silently skips persistence)
-- Never blocks on confirmation for unambiguous tasks (Phase 5 outputs immediately; Phase 6 writes a draft immediately)
-- File writes are limited to `<triage-dir>/<slug>.yaml` and `<slug>.draft.yaml` only — no other paths
-- **Never read `.claude/triage/` directly** (no inline `ls`, `Glob`, or `find`). The only read path is `scripts/triage-recall.mjs`, which enforces a stable contract so future sessions can rely on it
-- Output must be immediately actionable — copy-pasteable commands or prompts, no assumed knowledge
-- Exploration must never be silently dropped for Feature or Refactor classifications; for trivial scope, mark it optional but still surface it
+- Never dispatch agents; never modify source files.
+- Never hardcode a downstream skill name here — invocations always come from the current discovered config.
+- Works with zero `.claude/` config: generic prompts for every phase, persistence skipped silently.
+- Never block on confirmation for an unambiguous task — recommend first, draft immediately.
+- File writes are limited to `<triage-dir>/<slug>.yaml` and `<slug>.draft.yaml`.
+- Never read `.claude/triage/` with inline `ls`/`Glob`/`find` — `triage-recall.mjs` is the only read path, so future sessions can rely on a stable contract.
+- Never leave a record that fails `validate-record.mjs`.
+- Output must be copy-pasteable, with no assumed knowledge.

--- a/plugins/triage/skills/triage/SKILL.md
+++ b/plugins/triage/skills/triage/SKILL.md
@@ -62,25 +62,14 @@ Returns `[{"slug", "path"}]`, empty when there is no `specs/`. Halt on non-zero.
 
 ## Phase 2 — Classify and derive the flow
 
-Pick the classification that fits, then derive the phase sequence from the work itself — creative and restructuring work needs intent and constraints settled before code (Exploration → Planning → Implementation → Review); a bug needs the cause found before the patch (Debugging → Fix → Review); design work adds a Design Work phase before planning; a review request is just Review.
+Classify the task, then derive the phase sequence from the work itself, scaled to its actual scope: creative and restructuring work needs intent and constraints settled before code; a bug needs the cause found before the patch; design work needs the visual direction settled before anything is built; a review request is just Review.
 
-| Classification | Distinguishing signal |
-|---|---|
-| **UI Feature** | New page/component/layout; no significant data-layer change |
-| **Logic Feature** | New service, store, API integration, job; no significant UI |
-| **Mixed Feature** | New data flow *and* new UI to surface it |
-| **Bug Fix** | Broken, regressed, or flaky behavior |
-| **Refactor** | Restructuring with no behavior change |
-| **Design** | Visual/design-system work only — requirements exploration for a feature is *not* Design |
-| **Review** | Review of existing work |
-| **Other** | Ask one clarifying question; don't guess |
+`classification` is a schema enum — write one of `UI Feature`, `Logic Feature`, `Mixed Feature`, `Bug Fix`, `Refactor`, `Design`, `Review`, `Other` (see `references/triage-schema.md`). Two boundaries are genuinely counterintuitive and worth stating: exploring requirements for a feature is **not** `Design` — that value is for visual and design-system work only; and `Other` means stop and ask one clarifying question rather than force a fit.
 
 Two signals worth flagging explicitly, because they change the work and are easy to miss:
 
 - A bug in components with mobile-framework prefixes (`ion-*`, `Native*`) may be a platform-compat issue, not app logic.
 - A task touching files covered by an unrelated open spec is a conflict the user should decide on.
-
-For trivially-scoped tasks (copy change, one-token swap) keep Exploration in the flow but mark it `(optional — scope is self-evident)`; never drop it silently, since "trivial" is exactly where hidden scope hides.
 
 ---
 

--- a/plugins/triage/skills/triage/references/offload-scripts.md
+++ b/plugins/triage/skills/triage/references/offload-scripts.md
@@ -17,6 +17,19 @@ Scripts live **inside the owning skill's folder**:
 
 A script is only ever called by its owning SKILL.md. Cross-skill calls are forbidden — if two skills need the same logic, each gets its own copy. This keeps the skill folder the unit of audit, revert, and removal.
 
+### Exception: shared parsing within one plugin
+
+Inside a single plugin, skills MAY share a module that defines how a common artifact is *read*. The rule above assumes the skill folder is the unit of install and removal; in a plugin it isn't — the plugin is, and two copies of the same parser inside one shipped unit can only diverge.
+
+That divergence is not hypothetical. `yamlField` was duplicated across `triage-recall.mjs` and `scan-stale.mjs`; the copies drifted on which field held the record's date (`created` vs `created_at`), and records written with the other spelling became invisible to *both* resume and cleanup — permanently. One shared module is the fix.
+
+Scope of the exception, deliberately narrow:
+
+- **Shared:** the definition of the artifact's shape — field extraction and the schema's allowed values (`skills/triage/scripts/yaml-fields.mjs`).
+- **Not shared:** anything a skill decides. Staleness rules, confidence, thresholds, and deletion jails stay in the owning skill's own scripts.
+- Only within one plugin. Across plugins, copy.
+- The sharing must be named in the plugin's `CLAUDE.md`, so it stays a listed decision rather than a habit.
+
 ## Extension choice
 
 - `.sh` — pure glob / grep / `wc` / shell arithmetic / `jq` one-liners.
@@ -59,7 +72,7 @@ Where the pre-offload skill body is idempotent, the script must be too. Re-runni
 
 ## What scripts must not do
 
-- Call other scripts in other skills' folders.
+- Call other scripts in other skills' folders — except importing a same-plugin shared parsing module, per the exception above.
 - Mutate state outside the skill folder or the explicit file paths passed via argv.
 - Read from the environment.
 - Write to stdout on failure, or to stderr on success.

--- a/plugins/triage/skills/triage/references/phase5-persistence.md
+++ b/plugins/triage/skills/triage/references/phase5-persistence.md
@@ -1,4 +1,4 @@
-# Phase 6 — Persist the triage record
+# Phase 5 — Persist the triage record
 
 Read this before writing a triage record. Covers when the phase fires, the
 draft → in_progress confirmation gate, path resolution, slug rules, and what to
@@ -6,9 +6,9 @@ do after writing.
 
 Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`. This is how cross-session retrieval works — a future session invokes `triage-recall.mjs` (Phase 1a) and finds the record that this phase wrote.
 
-## When to fire Phase 6
+## When to fire Phase 5
 
-- **High confidence** → fire automatically, immediately after Phase 5 output. Write with `status: draft` and the filename suffix `.draft.yaml`. The draft exists so nothing is lost if the user walks away; it's explicitly marked so it doesn't pollute `--active` results as a decided plan.
+- **High confidence** → fire automatically, immediately after the Phase 4 output. Write with `status: draft` and the filename suffix `.draft.yaml`. The draft exists so nothing is lost if the user walks away; it's explicitly marked so it doesn't pollute `--active` results as a decided plan.
 - **Medium / Low confidence** → wait for the user to pick an interpretation (from the "If I Misclassified" block or the two-interpretation surface), then fire with `status: draft`.
 
 ## Confirmation gate (promotes draft → in_progress)
@@ -29,7 +29,7 @@ Contract: stdout JSON, one of:
 
 - `{"path":"<abs>","scope":"project"}` — preferred; versioned with the project. If the directory doesn't exist yet, create it with `mkdir -p` before writing.
 - `{"path":"<abs>","scope":"user"}` — fallback when the project has no `.claude/` dir.
-- `{"path":null,"scope":null}` — nothing configured; **skip Phase 6 silently**. Do not attempt to create `.claude/` in the project — that's a project-config decision, not a triage decision.
+- `{"path":null,"scope":null}` — nothing configured; **skip Phase 5 silently**. Do not attempt to create `.claude/` in the project — that's a project-config decision, not a triage decision.
 
 Non-zero + stderr on missing/relative `--root` or `--home`. Halt on non-zero and surface the diagnostic.
 
@@ -41,6 +41,16 @@ Non-zero + stderr on missing/relative `--root` or `--home`. Halt on non-zero and
 ## File contents
 
 Write the file using the schema in `references/triage-schema.md` — that document is the source of truth for fields, lifecycle states, and invariants. Read it before writing.
+
+## Validate every write
+
+Immediately after writing the draft, and again after promoting it:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/validate-record.mjs" --file "<abs path to record>"
+```
+
+Exit 0 means conformant. Exit 1 means it printed the violations: **fix the file and re-run until it exits 0.** This is not optional bookkeeping. An off-schema `status` or a date in `created_at` instead of `created` makes the record invisible to both `--active` recall and `/triage-cleanup` — it can then never be resumed and never be closed.
 
 ## After writing
 

--- a/plugins/triage/skills/triage/references/phase6-persistence.md
+++ b/plugins/triage/skills/triage/references/phase6-persistence.md
@@ -1,0 +1,49 @@
+# Phase 6 — Persist the triage record
+
+Read this before writing a triage record. Covers when the phase fires, the
+draft → in_progress confirmation gate, path resolution, slug rules, and what to
+do after writing.
+
+Triage produces a durable artifact: one YAML file per task at `.claude/triage/<slug>.yaml`. This is how cross-session retrieval works — a future session invokes `triage-recall.mjs` (Phase 1a) and finds the record that this phase wrote.
+
+## When to fire Phase 6
+
+- **High confidence** → fire automatically, immediately after Phase 5 output. Write with `status: draft` and the filename suffix `.draft.yaml`. The draft exists so nothing is lost if the user walks away; it's explicitly marked so it doesn't pollute `--active` results as a decided plan.
+- **Medium / Low confidence** → wait for the user to pick an interpretation (from the "If I Misclassified" block or the two-interpretation surface), then fire with `status: draft`.
+
+## Confirmation gate (promotes draft → in_progress)
+
+After the draft is written, tell the user:
+
+> `Saved as draft at <path>. Say "confirmed" (or start running the first recommended command) to promote to in_progress.`
+
+On confirmation — or when the user's next message clearly proceeds with the flow (e.g., invoking the first recommended skill) — rename `<slug>.draft.yaml` → `<slug>.yaml` and flip `status: draft` → `status: in_progress`. This two-step design prevents the old "user skipped confirmation ⇒ nothing saved" leak while keeping drafts distinguishable in git diffs and in recall.
+
+## Resolving the storage path
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/skills/triage/scripts/resolve-triage-path.mjs" --root "$(pwd)" --home "$HOME"
+```
+
+Contract: stdout JSON, one of:
+
+- `{"path":"<abs>","scope":"project"}` — preferred; versioned with the project. If the directory doesn't exist yet, create it with `mkdir -p` before writing.
+- `{"path":"<abs>","scope":"user"}` — fallback when the project has no `.claude/` dir.
+- `{"path":null,"scope":null}` — nothing configured; **skip Phase 6 silently**. Do not attempt to create `.claude/` in the project — that's a project-config decision, not a triage decision.
+
+Non-zero + stderr on missing/relative `--root` or `--home`. Halt on non-zero and surface the diagnostic.
+
+## Slug derivation
+
+- Lowercase, hyphen-separated, max 50 chars, stripped of punctuation.
+- If `<slug>.yaml` or `<slug>.draft.yaml` already exists for an unrelated task, append `-2`, `-3`, etc.
+
+## File contents
+
+Write the file using the schema in `references/triage-schema.md` — that document is the source of truth for fields, lifecycle states, and invariants. Read it before writing.
+
+## After writing
+
+- Output the exact first command to copy-paste and stop.
+- Do not begin implementation.
+- Do not add an entry to MEMORY.md — the triage directory is the index, reached through `triage-recall.mjs`.

--- a/plugins/triage/skills/triage/references/tool-shaped-skills.md
+++ b/plugins/triage/skills/triage/references/tool-shaped-skills.md
@@ -1,0 +1,19 @@
+# Tool-shaped supporting skills
+
+Second pass of Phase 4. Read this when the candidate list contains skills that
+are not phase-shaped — tools that augment whichever phase the user is in.
+
+Some skills aren't phase-shaped. They're tools that augment whichever phase the user is in: a code-structure search skill speeds up Exploration, Debugging, and Implementation alike; a library-docs lookup fires whenever the task touches a named framework. After the per-phase mapping above, run a second pass against the same candidate list using these intent signals:
+
+| Tool shape | Match on descriptions mentioning… |
+|---|---|
+| **Code understanding** | code structure search, AST traversal, symbol lookup, "instead of reading full files", structural code exploration, tree-sitter |
+| **Library docs** | library/framework/SDK documentation, API syntax lookup, version migration, library-specific debugging, "use when user asks about <lib>" |
+| **Memory recall** | persistent cross-session memory, prior-session lookup, "did we solve this before", cross-session search |
+| **MCP server** | any discovered `kind: "mcp-server"` record — match the server **name** (and `description` when present) to the shape it serves: docs servers (e.g. context7) → Library docs; memory servers (e.g. claude-mem) → Memory recall; code-graph/review servers (e.g. code-review-graph) → Code understanding / Review |
+
+**MCP servers are discovered, not assumed.** `discover-skills.mjs` emits `kind: "mcp-server"` records from the project `.mcp.json`, the user's `~/.claude.json` (this project's entry), and any installed plugin's `.mcp.json`. A server shipped by a plugin — e.g. a `code-review-graph` plugin — is therefore surfaced automatically with no plugin-specific knowledge baked into this skill. **Limitation:** discovery is server-level. The candidate record carries the server's name and (when the config provides one) its description — not its individual tool schemas, which are only available at runtime. Surface the server in the **Supporting Skills** block by name; do not claim specific tools it may expose.
+
+Surface every match in the recommendation's **Supporting Skills** block. Tool-shaped skills are not part of the phase sequence — they don't get tie-broken against phase matches and they don't get the generic-prompt fallback (if no tool-shaped skill matches a given shape, simply omit that shape from the block).
+
+For each match, write a one-sentence trigger condition tailored to *this task* (e.g., "fires when locating the existing auth middleware before editing it" — not the skill's generic description).

--- a/plugins/triage/skills/triage/references/tool-shaped-skills.md
+++ b/plugins/triage/skills/triage/references/tool-shaped-skills.md
@@ -1,6 +1,6 @@
 # Tool-shaped supporting skills
 
-Second pass of Phase 4. Read this when the candidate list contains skills that
+Second pass of Phase 3. Read this when the candidate list contains skills that
 are not phase-shaped — tools that augment whichever phase the user is in.
 
 Some skills aren't phase-shaped. They're tools that augment whichever phase the user is in: a code-structure search skill speeds up Exploration, Debugging, and Implementation alike; a library-docs lookup fires whenever the task touches a named framework. After the per-phase mapping above, run a second pass against the same candidate list using these intent signals:

--- a/plugins/triage/skills/triage/references/triage-schema.md
+++ b/plugins/triage/skills/triage/references/triage-schema.md
@@ -1,6 +1,6 @@
 # Triage Record Schema
 
-One YAML file per triaged task, stored at `.claude/triage/<slug>.yaml` (project scope) or the user-global fallback resolved by `resolve-triage-path.sh`.
+One YAML file per triaged task, stored at `.claude/triage/<slug>.yaml` (project scope) or the user-global fallback resolved by `resolve-triage-path.mjs`.
 
 ## Filename
 
@@ -26,7 +26,7 @@ phases:
     status: "<pending|complete|skipped>"
   - phase: "Planning"
     skill: "<mapped-skill-name>"
-    alternative: "<alternative-skill-name>"  # only when Phase 4 left two plausible skills
+    alternative: "<alternative-skill-name>"  # only when Phase 3 left two plausible skills
     scope: "..."
     status: "pending"
   # ...
@@ -41,7 +41,7 @@ notes:                                       # optional free-form
 ## Field semantics
 
 - **`status`** (top-level): lifecycle of the whole triage record.
-  - `draft` — written at Phase 6, not yet confirmed by user. File is `<slug>.draft.yaml`.
+  - `draft` — written at Phase 5, not yet confirmed by user. File is `<slug>.draft.yaml`.
   - `in_progress` — user confirmed; work is underway. File is `<slug>.yaml`.
   - `complete` — all phases complete, or user marked the whole task done.
   - `abandoned` — user explicitly abandoned; preserved for history but excluded from `--active`.
@@ -49,8 +49,19 @@ notes:                                       # optional free-form
   - `pending` — not started.
   - `complete` — finished (user confirmed or the skill marked it on re-invocation).
   - `skipped` — intentionally bypassed (e.g., Exploration on a trivial scope).
-- **`alternative`**: populated only when Phase 4's tie-breaker left two plausible skills for the same phase. The triage output surfaces it as `_Alternative: X — use if Y_`.
-- **`supporting_skills`**: tool-shaped skills (code-structure search, library-docs lookup, cross-session memory recall) that augment any phase rather than owning one. Populated by Phase 4's second pass. Omitted entirely if no tool-shaped skill matched. `when` is a per-task trigger condition, not the skill's generic description.
+- **`alternative`**: populated only when Phase 3's tie-breaker left two plausible skills for the same phase. The triage output surfaces it as `_Alternative: X — use if Y_`.
+- **`supporting_skills`**: tool-shaped skills (code-structure search, library-docs lookup, cross-session memory recall) that augment any phase rather than owning one. Populated by Phase 3's second pass. Omitted entirely if no tool-shaped skill matched. `when` is a per-task trigger condition, not the skill's generic description.
+
+## Validation
+
+`skills/triage/scripts/validate-record.mjs --file <abs>` is the enforcement point for everything above: exit 0 conformant, exit 1 with the violations printed, exit 2 on bad argv. It checks that `status` and every `phases[].status` are on-schema, that `task` is present, and that the date lives in `created` as `YYYY-MM-DD`.
+
+Three field-level rules exist because breaking them makes a record permanently invisible — unreadable by `triage-recall --active` (so it can never be resumed) *and* unclassifiable by `scan-stale` (so cleanup can never close it):
+
+- **`created` is the only accepted spelling.** `created_at` is tolerated on read for the sake of records already in the wild, and rejected on write.
+- **`status` must be one of the four values.** Anything else (`implementation_complete`, `resolved`, …) satisfies no lifecycle rule.
+- **`status` must be present.** A record with no status has no lifecycle at all.
+- **`phases[].status` must be one of the three values.** Readers normalize the known synonyms (`completed`/`done`/`finished` → `complete`; `deferred`/`rejected`/`n/a` → `skipped`) so existing records grade correctly, and writes are rejected — the tolerance exists to absorb history, not to widen the vocabulary. Anything *unrecognised* counts as not-done, which can only keep a record out of the delete set, never push it in.
 
 ## Invariants
 

--- a/plugins/triage/skills/triage/scripts/triage-recall.mjs
+++ b/plugins/triage/skills/triage/scripts/triage-recall.mjs
@@ -10,6 +10,7 @@
 // Exactly one of --active|--find|--show. Exit 0 even when empty; exit 2 + stderr on bad argv.
 import { statSync, readdirSync, readFileSync } from "node:fs";
 import { isAbsolute, join, basename } from "node:path";
+import { yamlField, recordCreated } from "./yaml-fields.mjs";
 
 function die(msg) { process.stderr.write(`triage-recall: ${msg}\n`); process.exit(2); }
 function isDir(p) { try { return statSync(p).isDirectory(); } catch { return false; } }
@@ -32,15 +33,6 @@ if (!isAbsolute(dir)) die(`--dir must be absolute: ${dir}`);
 
 if (!isDir(dir)) { process.stdout.write(json ? "[]\n" : "(no triage records)\n"); process.exit(0); }
 
-// Extract a single top-level scalar `^field: value`; strip a leading and a trailing quote
-// independently (mirrors the original awk gsub behavior). Returns "" when absent.
-function yamlField(content, field) {
-  const esc = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const m = content.match(new RegExp(`^${esc}:[ \\t]*(.*)$`, "m"));
-  if (!m) return "";
-  return m[1].replace(/^["']/, "").replace(/["']$/, "");
-}
-
 function baseSlug(file) {
   return basename(file).replace(/\.yaml$/, "").replace(/\.draft$/, "");
 }
@@ -58,7 +50,7 @@ function record(file) {
     slug: baseSlug(file),
     status: yamlField(c, "status"),
     task: yamlField(c, "task"),
-    created: yamlField(c, "created"),
+    created: recordCreated(c),
     classification: yamlField(c, "classification"),
     path: file,
   };

--- a/plugins/triage/skills/triage/scripts/validate-record.mjs
+++ b/plugins/triage/skills/triage/scripts/validate-record.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// Serves: triage SKILL.md — Phase 6 post-write check on a triage record.
+// The deterministic guard on the schema: a record that passes here stays readable by
+// triage-recall (--active) and classifiable by scan-stale (cleanup). Without it the
+// lifecycle drifts — off-schema statuses and misspelled date fields make a record
+// permanently invisible to both, so it can never be resumed and never be cleaned up.
+//
+// Inputs (argv):
+//   --file <abs>   required — the record just written.
+//   --json         machine-readable output (default: human-readable lines).
+// stdout: findings (empty when valid). Exit 0 when valid, 1 when the record has
+// violations, 2 + stderr on bad argv or unreadable file.
+import { readFileSync, statSync } from "node:fs";
+import { isAbsolute } from "node:path";
+import { yamlField, phaseStatuses, PHASE_STATUS_ALIASES, TRIAGE_STATUSES, PHASE_STATUSES } from "./yaml-fields.mjs";
+
+function die(msg) { process.stderr.write(`validate-record: ${msg}\n`); process.exit(2); }
+
+const argv = process.argv.slice(2);
+let file = "", json = false;
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a === "--file") { if (i + 1 >= argv.length) die("--file requires a value"); file = argv[++i]; }
+  else if (a === "--json") json = true;
+  else die(`unknown arg: ${a}`);
+}
+if (!file) die("--file is required");
+if (!isAbsolute(file)) die(`--file must be absolute: ${file}`);
+try { if (!statSync(file).isFile()) die(`not a file: ${file}`); } catch { die(`cannot read: ${file}`); }
+
+const content = readFileSync(file, "utf8");
+const violations = [];
+
+// --- top-level status ------------------------------------------------------
+const status = yamlField(content, "status").trim();
+if (!status) {
+  violations.push({ field: "status", value: "", message: "missing — record cannot be classified as active or stale" });
+} else if (!TRIAGE_STATUSES.includes(status)) {
+  violations.push({
+    field: "status",
+    value: status,
+    message: `off-schema — must be one of ${TRIAGE_STATUSES.join("|")}`,
+  });
+}
+
+// --- creation date ---------------------------------------------------------
+// `created_at` reads fine (yaml-fields accepts both) but writes must use the schema
+// spelling, or the next script added to the plugin inherits the same blind spot.
+const created = yamlField(content, "created").trim();
+const createdAt = yamlField(content, "created_at").trim();
+if (!created && createdAt) {
+  violations.push({ field: "created_at", value: createdAt, message: "wrong field name — the schema field is `created`" });
+} else if (!created) {
+  violations.push({ field: "created", value: "", message: "missing — age-based cleanup cannot see this record" });
+} else if (!/^\d{4}-\d{2}-\d{2}$/.test(created)) {
+  violations.push({ field: "created", value: created, message: "must be YYYY-MM-DD" });
+}
+
+// --- task ------------------------------------------------------------------
+// Recall matches on this field; an empty one is unfindable in a later session.
+if (!yamlField(content, "task").trim()) {
+  violations.push({ field: "task", value: "", message: "missing — the record cannot be found by --find in a later session" });
+}
+
+// --- phase statuses --------------------------------------------------------
+// Readers tolerate the known synonyms so old records still grade correctly, but a write
+// that introduces one is how the vocabulary drifted to ten values for three states.
+for (const s of phaseStatuses(content)) {
+  if (PHASE_STATUSES.includes(s)) continue;
+  const canonical = PHASE_STATUS_ALIASES[s.toLowerCase()];
+  violations.push({
+    field: "phases[].status",
+    value: s,
+    message: canonical
+      ? `off-schema synonym — write "${canonical}" instead`
+      : `off-schema — must be one of ${PHASE_STATUSES.join("|")}`,
+  });
+}
+
+if (json) {
+  process.stdout.write(`${JSON.stringify({ file, valid: violations.length === 0, violations })}\n`);
+} else if (violations.length) {
+  process.stdout.write(`${file}\n`);
+  for (const v of violations) {
+    process.stdout.write(`  ${v.field}${v.value ? ` (${v.value})` : ""}: ${v.message}\n`);
+  }
+}
+process.exit(violations.length ? 1 : 0);

--- a/plugins/triage/skills/triage/scripts/yaml-fields.mjs
+++ b/plugins/triage/skills/triage/scripts/yaml-fields.mjs
@@ -1,0 +1,61 @@
+// Shared record-parsing helpers for the triage plugin's scripts.
+// Every script that reads a triage YAML MUST read it through here: triage-recall,
+// scan-stale, and validate-record diverged on field names once already (`created`
+// vs `created_at`), which made malformed records invisible to cleanup.
+//
+// Deliberately not a YAML parser — records are flat enough that two regexes cover
+// them, and a dependency-free plugin is a hard repo convention.
+
+// Lifecycle values the schema allows. Anything else is drift, and callers should
+// surface it rather than silently ignore the record.
+export const TRIAGE_STATUSES = ["draft", "in_progress", "complete", "abandoned"];
+export const PHASE_STATUSES = ["pending", "complete", "skipped"];
+
+// Extract a single top-level scalar `^field: value`; strip a leading and a trailing
+// quote independently (mirrors the original awk gsub behavior, which golden-output
+// tests lock). Does NOT trim — callers that want trimming ask for it.
+export function yamlField(content, field) {
+  const esc = field.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const m = content.match(new RegExp(`^${esc}:[ \\t]*(.*)$`, "m"));
+  if (!m) return "";
+  return m[1].replace(/^["']/, "").replace(/["']$/, "");
+}
+
+// Statuses of list items under `phases:` — indented `status:` lines only
+// (the top-level record status has no indent).
+export function phaseStatuses(content) {
+  return [...content.matchAll(/^[ \t]+status:[ \t]*(\S+)/gm)].map((m) => m[1].replace(/["']/g, ""));
+}
+
+// The record's creation date. Records in the wild use both spellings; `created` is
+// the schema's, `created_at` is what some sessions wrote. Accept both on read so a
+// misspelled record is still ageable — validate-record.mjs is what rejects it on write.
+export function recordCreated(content) {
+  return (yamlField(content, "created") || yamlField(content, "created_at")).trim();
+}
+
+// Synonyms real records use for the three phase states. Measured across 36 records:
+// `completed` (30) and `done` (4) outnumbered nothing, but they meant exactly `complete`
+// — and a strict reader graded those finished records as unfinished. Tolerate on read,
+// reject on write, same contract as `created_at`.
+export const PHASE_STATUS_ALIASES = {
+  completed: "complete",
+  done: "complete",
+  finished: "complete",
+  deferred: "skipped",
+  rejected: "skipped",
+  "n/a": "skipped",
+};
+
+export function normalizePhaseStatus(s) {
+  const v = String(s).trim().toLowerCase();
+  return PHASE_STATUS_ALIASES[v] ?? v;
+}
+
+// Is this phase closed out — either finished or intentionally bypassed?
+// Anything unrecognised (`partial`, `code-complete`, `in_progress`) counts as NOT done, so
+// an unfamiliar vocabulary can only ever keep a record out of the delete set, never push it in.
+export function phaseIsDone(s) {
+  const n = normalizePhaseStatus(s);
+  return n === "complete" || n === "skipped";
+}

--- a/plugins/triage/test/delete-targets.test.mjs
+++ b/plugins/triage/test/delete-targets.test.mjs
@@ -1,0 +1,105 @@
+// test/delete-targets.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage-cleanup/scripts/delete-targets.mjs", import.meta.url));
+const run = (args) => JSON.parse(execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" }));
+const runFail = (args) => {
+  try { execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }); return null; }
+  catch (e) { return { status: e.status, stderr: e.stderr }; }
+};
+
+function seed() {
+  const root = mkdtempSync(join(tmpdir(), "dt-"));
+  const a = join(root, "a.yaml");
+  const b = join(root, "b.yaml");
+  writeFileSync(a, "x");
+  writeFileSync(b, "y");
+  return { root, a, b };
+}
+
+test("deletes targets inside the jail", () => {
+  const { root, a, b } = seed();
+  const out = run(["--allow-root", root, "--target", a, "--target", b]);
+  assert.deepEqual(out.deleted.sort(), [a, b].sort());
+  assert.equal(existsSync(a), false);
+  assert.equal(existsSync(b), false);
+});
+
+test("--dry-run touches nothing", () => {
+  const { root, a } = seed();
+  const out = run(["--allow-root", root, "--target", a, "--dry-run"]);
+  assert.deepEqual(out.wouldDelete, [a]);
+  assert.deepEqual(out.deleted, []);
+  assert.equal(existsSync(a), true);
+});
+
+test("a target outside the jail aborts the whole batch — nothing deleted", () => {
+  const { root, a } = seed();
+  const outside = mkdtempSync(join(tmpdir(), "dt-out-"));
+  const evil = join(outside, "victim.yaml");
+  writeFileSync(evil, "z");
+  const r = runFail(["--allow-root", root, "--target", a, "--target", evil]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /escapes all --allow-root/);
+  assert.equal(existsSync(a), true);   // batch aborted: the in-jail file survives too
+  assert.equal(existsSync(evil), true);
+});
+
+test("path traversal that escapes the jail is rejected", () => {
+  const { root } = seed();
+  const escape = join(root, "..", "etc-passwd-ish");
+  const r = runFail(["--allow-root", root, "--target", escape]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /escapes all/);
+});
+
+test("a directory target aborts the batch", () => {
+  const { root } = seed();
+  const sub = join(root, "sub");
+  mkdirSync(sub);
+  const r = runFail(["--allow-root", root, "--target", sub]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /directory/);
+});
+
+test("missing file is skipped, not fatal", () => {
+  const { root, a } = seed();
+  const ghost = join(root, "ghost.yaml");
+  const out = run(["--allow-root", root, "--target", a, "--target", ghost]);
+  assert.deepEqual(out.deleted, [a]);
+  assert.equal(out.skipped[0].path, ghost);
+  assert.match(out.skipped[0].reason, /not found/);
+});
+
+test("manifest file form works (array and {targets})", () => {
+  const { root, a, b } = seed();
+  const m1 = join(root, "m1.json");
+  writeFileSync(m1, JSON.stringify([a]));
+  assert.deepEqual(run(["--allow-root", root, "--manifest", m1]).deleted, [a]);
+
+  const m2 = join(root, "m2.json");
+  writeFileSync(m2, JSON.stringify({ targets: [b] }));
+  assert.deepEqual(run(["--allow-root", root, "--manifest", m2]).deleted, [b]);
+});
+
+test("multiple allow-roots: a target in the second jail is accepted", () => {
+  const { root, a } = seed();
+  const root2 = mkdtempSync(join(tmpdir(), "dt2-"));
+  const c = join(root2, "c.yaml");
+  writeFileSync(c, "c");
+  const out = run(["--allow-root", root, "--allow-root", root2, "--target", a, "--target", c]);
+  assert.deepEqual(out.deleted.sort(), [a, c].sort());
+});
+
+test("bad argv exits 2", () => {
+  assert.equal(runFail(["--target", "/x/y.yaml"]).status, 2);            // no allow-root
+  assert.equal(runFail(["--allow-root", "rel", "--target", "/x"]).status, 2); // relative allow-root
+  assert.equal(runFail(["--allow-root", "/abs"]).status, 2);             // no targets
+  assert.equal(runFail(["--allow-root", "/abs", "--target", "rel"]).status, 2); // relative target
+});

--- a/plugins/triage/test/scan-stale.test.mjs
+++ b/plugins/triage/test/scan-stale.test.mjs
@@ -1,0 +1,317 @@
+// test/scan-stale.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage-cleanup/scripts/scan-stale.mjs", import.meta.url));
+const NOW = "2026-06-24";
+const run = (args) => JSON.parse(execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" }));
+const runFail = (args) => {
+  try { execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }); return null; }
+  catch (e) { return { status: e.status, stderr: e.stderr }; }
+};
+
+// Set a file's mtime to `daysAgo` before NOW so age math is deterministic.
+function age(path, daysAgo) {
+  const t = (Date.parse(`${NOW}T00:00:00Z`) - daysAgo * 86_400_000) / 1000;
+  utimesSync(path, t, t);
+}
+
+function project() {
+  const root = mkdtempSync(join(tmpdir(), "tc-root-"));
+  const triageDir = join(root, ".claude", "triage");
+  mkdirSync(triageDir, { recursive: true });
+  return { root, triageDir };
+}
+
+const yaml = (fields, phases = []) => {
+  let s = Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join("\n") + "\n";
+  if (phases.length) s += "phases:\n" + phases.map((p) => `  - phase: X\n    status: ${p}\n`).join("");
+  return s;
+};
+
+function byPath(report) {
+  const m = {};
+  for (const c of report.candidates) m[c.path] = c;
+  return m;
+}
+
+test("abandoned + complete(all done) are high-confidence candidates; active in_progress is not", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "gave-up.yaml"), yaml({ task: "X", status: "abandoned", created: "2026-06-01" }));
+  writeFileSync(join(triageDir, "done.yaml"), yaml({ task: "Y", status: "complete", created: "2026-06-01" }, ["complete", "skipped"]));
+  writeFileSync(join(triageDir, "working.yaml"), yaml({ task: "Z", status: "in_progress", created: "2026-06-20" }, ["pending"]));
+
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  const c = byPath(r);
+  assert.equal(c[join(triageDir, "gave-up.yaml")].confidence, "high");
+  assert.equal(c[join(triageDir, "done.yaml")].confidence, "high");
+  assert.equal(c[join(triageDir, "working.yaml")], undefined); // active, not a candidate
+  assert.equal(r.summary.autoDeletable, 2);
+});
+
+test("phase-status synonyms still count as finished", () => {
+  const { root, triageDir } = project();
+  // `completed`/`done` are what real records actually contain; a strict reader graded
+  // these finished records as unfinished and downgraded them to medium.
+  writeFileSync(join(triageDir, "syn.yaml"),
+    yaml({ task: "X", status: "complete", created: "2026-06-01" }, ["completed", "done", "deferred"]));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates[0].confidence, "high");
+  assert.match(r.candidates[0].reason, /all phases finished/);
+});
+
+test("an unrecognised phase status keeps a record out of the high-confidence set", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "odd-phase.yaml"),
+    yaml({ task: "X", status: "complete", created: "2026-06-01" }, ["complete", "code-complete"]));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates[0].confidence, "medium");
+});
+
+test("complete but phases unfinished is medium, not high", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "half.yaml"), yaml({ task: "X", status: "complete", created: "2026-06-01" }, ["complete", "pending"]));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(byPath(r).candidates?.length ?? r.candidates.length, 1);
+  assert.equal(r.candidates[0].confidence, "medium");
+});
+
+test("stale draft (older than draft-age) is a candidate; fresh draft is not", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "old.draft.yaml"), yaml({ task: "X", status: "draft", created: "2026-05-01" })); // 54d
+  writeFileSync(join(triageDir, "new.draft.yaml"), yaml({ task: "Y", status: "draft", created: "2026-06-20" })); // 4d
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  const slugs = r.candidates.map((c) => c.slug);
+  assert.deepEqual(slugs, ["old"]);
+  assert.equal(r.candidates[0].confidence, "medium");
+});
+
+test("stale in_progress is flag-only/low; never counted as autoDeletable", () => {
+  const { root, triageDir } = project();
+  const f = join(triageDir, "stuck.yaml");
+  writeFileSync(f, yaml({ task: "X", status: "in_progress", created: "2026-03-01" }, ["pending"]));
+  age(f, 115); // untouched for 115d — staleness is measured from last touch, not creation
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates.length, 1);
+  assert.equal(r.candidates[0].confidence, "low");
+  assert.equal(r.candidates[0].flagOnly, true);
+  assert.equal(r.summary.autoDeletable, 0);
+});
+
+test("long-running but recently touched in_progress is NOT stale", () => {
+  const { root, triageDir } = project();
+  const f = join(triageDir, "active-epic.yaml");
+  writeFileSync(f, yaml({ task: "Long epic", status: "in_progress", created: "2026-01-01" }, ["pending"])); // 174d old
+  age(f, 2); // but worked on two days ago
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates.length, 0);
+  assert.ok(r.active.some((a) => a.slug === "active-epic"));
+});
+
+test("created_at (wrong field name) is still ageable, not silently immortal", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "misspelled.draft.yaml"),
+    yaml({ task: "X", status: "draft", created_at: "2026-05-01" })); // 54d
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates.length, 1);
+  assert.equal(r.candidates[0].ageDays, 54);
+  assert.equal(r.candidates[0].confidence, "medium");
+});
+
+test("needsRepair agrees with validate-record: created_at counts, tolerant read notwithstanding", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "misspelled.yaml"),
+    yaml({ task: "X", status: "in_progress", created_at: "2026-06-20" }, ["pending"]));
+  writeFileSync(join(triageDir, "clean.yaml"),
+    yaml({ task: "Y", status: "in_progress", created: "2026-06-20" }, ["pending"]));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  const all = [...r.candidates, ...r.active];
+  assert.equal(all.find((x) => x.slug === "misspelled").needsRepair, true);
+  assert.equal(all.find((x) => x.slug === "clean").needsRepair, false);
+  assert.equal(r.summary.needsRepair, 1);
+});
+
+test("off-schema status is flagged rather than treated as active forever", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "odd.yaml"),
+    yaml({ task: "X", status: "implementation_complete", created: "2026-06-01" }, ["complete"]));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates.length, 1);
+  assert.equal(r.candidates[0].flagOnly, true);
+  assert.match(r.candidates[0].reason, /off-schema status/);
+  assert.equal(r.summary.autoDeletable, 0);
+});
+
+test("record with no status field is flagged, not counted as active", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "headless.yaml"), yaml({ task: "X", created: "2026-06-01" }));
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(r.candidates.length, 1);
+  assert.equal(r.candidates[0].flagOnly, true);
+  assert.match(r.candidates[0].reason, /no status field/);
+});
+
+test("a spec of an off-schema-status record stays protected", () => {
+  const { root, triageDir } = project();
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "guarded.md");
+  writeFileSync(spec, "# guarded\n");
+  age(spec, 300);
+  writeFileSync(join(triageDir, "odd.yaml"),
+    yaml({ task: "X", status: "implementation_complete", created: "2026-06-01" }) + 'notes:\n  - "specs/guarded.md"\n');
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(byPath(r)[spec], undefined); // not a delete candidate
+  assert.ok(r.active.some((a) => a.path === spec));
+});
+
+test("basename-only reference match is medium, never high", () => {
+  const { root, triageDir } = project();
+  mkdirSync(join(root, "docs", "archive"), { recursive: true });
+  const twin = join(root, "docs", "archive", "sso.md"); // same filename, different path
+  writeFileSync(twin, "# unrelated archive copy\n");
+  age(twin, 100);
+  writeFileSync(join(triageDir, "sso.yaml"),
+    yaml({ task: "SSO", status: "complete", created: "2026-06-01" }, ["complete"]) + 'notes:\n  - "specs/sso.md"\n');
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  const c = byPath(r)[twin];
+  assert.equal(c.confidence, "medium");
+  assert.match(c.reason, /not its path/);
+});
+
+test("git commit date beats mtime for artifact age", () => {
+  const { root } = project();
+  const git = (...args) => execFileSync("git", ["-C", root, ...args], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_DATE: "2026-05-01T12:00:00Z", GIT_COMMITTER_DATE: "2026-05-01T12:00:00Z",
+      GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@e", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@e",
+    },
+  });
+  git("init", "-q");
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "committed.md");
+  writeFileSync(spec, "# committed\n");
+  git("add", "specs/committed.md");
+  git("commit", "-qm", "add spec");
+  age(spec, 0); // checkout-style fresh mtime, which would hide a 54-day-old artifact
+
+  const r = run(["--root", root, "--now", NOW]);
+  const c = byPath(r)[spec];
+  assert.ok(c, "committed spec should be an orphan candidate on its real age");
+  assert.equal(c.ageSource, "git");
+  assert.equal(c.ageDays, 54); // 2026-05-01 -> 2026-06-24
+});
+
+test("spec referenced by a complete triage is a high-confidence candidate", () => {
+  const { root, triageDir } = project();
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "sso.md");
+  writeFileSync(spec, "# SSO\n");
+  age(spec, 5);
+  writeFileSync(join(triageDir, "sso.yaml"),
+    yaml({ task: "SSO", status: "complete", created: "2026-06-01" }, ["complete"]) + 'notes:\n  - "specs/sso.md"\n');
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  const c = byPath(r)[spec];
+  assert.equal(c.kind, "spec");
+  assert.equal(c.confidence, "high");
+  assert.match(c.reason, /complete\/abandoned triage/);
+});
+
+test("spec referenced by an active triage is protected (not a candidate)", () => {
+  const { root, triageDir } = project();
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "live.md");
+  writeFileSync(spec, "# live\n");
+  age(spec, 200);
+  writeFileSync(join(triageDir, "live.yaml"),
+    yaml({ task: "Live", status: "in_progress", created: "2026-06-20" }, ["pending"]) + 'notes:\n  - "specs/live.md"\n');
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", triageDir]);
+  assert.equal(byPath(r)[spec], undefined);
+  assert.ok(r.active.some((a) => a.path === spec));
+});
+
+test("orphaned old spec is low/flag-only; recent orphan is left alone", () => {
+  const { root } = project();
+  mkdirSync(join(root, "specs"));
+  const old = join(root, "specs", "ancient.md");
+  const fresh = join(root, "specs", "recent.md");
+  writeFileSync(old, "# old\n"); age(old, 90);
+  writeFileSync(fresh, "# new\n"); age(fresh, 3);
+  const r = run(["--root", root, "--now", NOW]);
+  const c = byPath(r);
+  assert.equal(c[old].confidence, "low");
+  assert.equal(c[old].flagOnly, true);
+  assert.equal(c[fresh], undefined);
+});
+
+test("plain docs/ file with no triage link is never a candidate", () => {
+  const { root } = project();
+  mkdirSync(join(root, "docs"));
+  const readme = join(root, "docs", "guide.md");
+  writeFileSync(readme, "# guide\n"); age(readme, 365);
+  const r = run(["--root", root, "--now", NOW]);
+  assert.equal(byPath(r)[readme], undefined);
+  assert.ok(r.active.some((a) => a.path === readme && /permanent/.test(a.reason)));
+});
+
+test("docs/**/plans/ file is treated as a plan (orphan-eligible)", () => {
+  const { root } = project();
+  mkdirSync(join(root, "docs", "superpowers", "plans"), { recursive: true });
+  const plan = join(root, "docs", "superpowers", "plans", "rollout.md");
+  writeFileSync(plan, "# plan\n"); age(plan, 90);
+  const r = run(["--root", root, "--now", NOW]);
+  const c = byPath(r)[plan];
+  assert.equal(c.kind, "plan");
+  assert.equal(c.flagOnly, true);
+});
+
+test("--dir adds a user-named artifact directory", () => {
+  const { root } = project();
+  const extra = mkdtempSync(join(tmpdir(), "tc-extra-"));
+  const f = join(extra, "design.md");
+  writeFileSync(f, "# design\n"); age(f, 90);
+  // extra dir isn't specs/plans, so it classifies as doc -> not orphan-eligible; still discovered as active.
+  const r = run(["--root", root, "--now", NOW, "--dir", extra]);
+  assert.ok([...r.candidates, ...r.active].some((x) => x.path === f));
+});
+
+test("no triage dir -> empty triage candidates, still scans specs", () => {
+  const { root } = project();
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "x.md");
+  writeFileSync(spec, "# x\n"); age(spec, 90);
+  const r = run(["--root", root, "--now", NOW]); // no --triage-dir
+  assert.equal(r.triageDir, null);
+  assert.ok(byPath(r)[spec]);
+});
+
+test("custom --draft-age threshold is honored", () => {
+  const { root, triageDir } = project();
+  writeFileSync(join(triageDir, "d.draft.yaml"), yaml({ task: "X", status: "draft", created: "2026-06-10" })); // 14d
+  assert.equal(run(["--root", root, "--now", NOW, "--triage-dir", triageDir]).candidates.length, 0); // default 30
+  assert.equal(run(["--root", root, "--now", NOW, "--triage-dir", triageDir, "--draft-age", "7"]).candidates.length, 1);
+});
+
+test("empty --triage-dir is treated as 'no triage dir' (SKILL.md passes it unconditionally)", () => {
+  const { root } = project();
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "x.md");
+  writeFileSync(spec, "# x\n"); age(spec, 90);
+  const r = run(["--root", root, "--now", NOW, "--triage-dir", ""]);
+  assert.equal(r.triageDir, null);   // empty string -> null, no crash
+  assert.ok(byPath(r)[spec]);        // spec scan still runs
+});
+
+test("bad argv exits 2", () => {
+  assert.equal(runFail(["--now", NOW]).status, 2);                       // missing --root
+  assert.equal(runFail(["--root", "rel", "--now", NOW]).status, 2);      // relative root
+  assert.equal(runFail(["--root", "/abs"]).status, 2);                   // missing --now
+  assert.equal(runFail(["--root", "/abs", "--now", "nope"]).status, 2);  // bad date
+});

--- a/plugins/triage/test/triage-heartbeat.test.mjs
+++ b/plugins/triage/test/triage-heartbeat.test.mjs
@@ -1,0 +1,159 @@
+// test/triage-heartbeat.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readdirSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HOOK = fileURLToPath(new URL("../hooks/triage-heartbeat.mjs", import.meta.url));
+
+const run = (root, dataDir, args = []) =>
+  execFileSync("node", [HOOK, ...args], {
+    encoding: "utf8",
+    input: JSON.stringify({ hook_event_name: "SessionStart", cwd: root }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, CLAUDE_PLUGIN_DATA: dataDir ?? "" },
+  });
+
+const dataDir = () => mkdtempSync(join(tmpdir(), "thbdata-"));
+
+// `withTriageDir: false` gives a project that has .claude/ but has never triaged —
+// the case the resolver still answers with a path for.
+function project({ withClaude = true, withTriageDir = true } = {}) {
+  const root = mkdtempSync(join(tmpdir(), "thb-"));
+  if (withClaude) mkdirSync(join(root, ".claude"), { recursive: true });
+  if (withTriageDir) mkdirSync(join(root, ".claude", "triage"), { recursive: true });
+  return root;
+}
+
+const yaml = (fields, phases = []) => {
+  let s = Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join("\n") + "\n";
+  if (phases.length) s += "phases:\n" + phases.map((p) => `  - phase: X\n    status: ${p}\n`).join("");
+  return s;
+};
+
+const today = () => new Date().toISOString().slice(0, 10);
+const isoDaysAgo = (d) => new Date(Date.now() - d * 86_400_000).toISOString().slice(0, 10);
+
+function record(root, name, fields, phases = [], ageDays = 0) {
+  const f = join(root, ".claude", "triage", name);
+  writeFileSync(f, yaml(fields, phases));
+  if (ageDays) {
+    const t = (Date.now() - ageDays * 86_400_000) / 1000;
+    utimesSync(f, t, t);
+  }
+  return f;
+}
+
+const ctx = (out) => JSON.parse(out).hookSpecificOutput.additionalContext;
+
+test("silent when the project has no .claude/ at all", () => {
+  assert.equal(run(project({ withClaude: false, withTriageDir: false }), dataDir()), "");
+});
+
+test("silent when .claude/ exists but the project never triaged", () => {
+  // The resolver returns a path here regardless; only an existing, populated dir counts.
+  const root = project({ withTriageDir: false });
+  mkdirSync(join(root, "specs"));
+  const spec = join(root, "specs", "ancient.md");
+  writeFileSync(spec, "# old\n");
+  const t = (Date.now() - 400 * 86_400_000) / 1000;
+  utimesSync(spec, t, t);
+  assert.equal(run(root, dataDir()), "");
+});
+
+test("silent when the triage dir exists but holds no records", () => {
+  assert.equal(run(project(), dataDir()), "");
+});
+
+test("silent on a healthy, recently-touched record", () => {
+  const root = project();
+  record(root, "live.yaml", { task: "X", status: "in_progress", created: isoDaysAgo(3) }, ["pending"]);
+  assert.equal(run(root, dataDir()), "");
+});
+
+test("speaks when a finished record is safe to close out", () => {
+  const root = project();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete", "skipped"]);
+  const out = run(root, dataDir());
+  assert.match(ctx(out), /1 finished or abandoned artifact/);
+  assert.match(ctx(out), /\/triage-cleanup/);
+  assert.match(ctx(out), /cannot see this note/);
+});
+
+test("an off-schema status is reported as repair, not as likely dead", () => {
+  const root = project();
+  record(root, "odd.yaml", { task: "X", status: "implementation_complete", created: isoDaysAgo(10) }, ["complete"]);
+  const c = ctx(run(root, dataDir()));
+  assert.match(c, /off-schema status or date field: repair, don't delete/);
+  assert.doesNotMatch(c, /likely dead/);
+  assert.match(c, /validate-record/);
+});
+
+test("flag-only records below --min-flagged stay silent", () => {
+  const root = project();
+  // Two long-dead in_progress records: real, but nothing here is safe to act on yet.
+  record(root, "a.yaml", { task: "A", status: "in_progress", created: isoDaysAgo(120) }, ["pending"], 100);
+  record(root, "b.yaml", { task: "B", status: "in_progress", created: isoDaysAgo(120) }, ["pending"], 100);
+  assert.equal(run(root, dataDir(), ["--min-flagged", "5"]), "");
+});
+
+test("flag-only records at --min-flagged speak", () => {
+  const root = project();
+  for (const n of ["a", "b", "c"]) {
+    record(root, `${n}.yaml`, { task: n, status: "in_progress", created: isoDaysAgo(120) }, ["pending"], 100);
+  }
+  const c = ctx(run(root, dataDir(), ["--min-flagged", "3"]));
+  assert.match(c, /3 record\(s\) flagged as likely dead/);
+  assert.match(c, /never auto-deleted/);
+});
+
+test("throttle: a second run inside the window is silent, and state is persisted", () => {
+  const root = project();
+  const data = dataDir();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete"]);
+  assert.notEqual(run(root, data), "");
+  assert.equal(run(root, data), "");
+  assert.ok(readdirSync(data).includes("triage-heartbeat-state.json"));
+});
+
+test("--frequency 0 disables the throttle", () => {
+  const root = project();
+  const data = dataDir();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete"]);
+  assert.notEqual(run(root, data, ["--frequency", "0"]), "");
+  assert.notEqual(run(root, data, ["--frequency", "0"]), "");
+});
+
+test("no CLAUDE_PLUGIN_DATA degrades to checking every time, never to a crash", () => {
+  const root = project();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete"]);
+  assert.notEqual(run(root, ""), "");
+  assert.notEqual(run(root, ""), "");
+});
+
+test("garbage on stdin and a missing cwd still exit 0", () => {
+  const root = project();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete"]);
+  const out = execFileSync("node", [HOOK], {
+    encoding: "utf8",
+    input: "not json at all",
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, CLAUDE_PLUGIN_DATA: "" },
+  });
+  assert.match(ctx(out), /triage-cleanup/);
+});
+
+test("emits nothing but valid JSON, and never writes to stderr", () => {
+  const root = project();
+  record(root, "done.yaml", { task: "X", status: "complete", created: isoDaysAgo(40) }, ["complete"]);
+  const res = execFileSync("node", [HOOK], {
+    encoding: "utf8",
+    input: JSON.stringify({ cwd: root }),
+    env: { ...process.env, CLAUDE_PROJECT_DIR: root, CLAUDE_PLUGIN_DATA: "" },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const parsed = JSON.parse(res); // throws if the hook printed anything else
+  assert.equal(parsed.hookSpecificOutput.hookEventName, "SessionStart");
+  assert.equal(today().length, 10); // guards the --now format the hook passes to the scanner
+});

--- a/plugins/triage/test/validate-record.test.mjs
+++ b/plugins/triage/test/validate-record.test.mjs
@@ -1,0 +1,99 @@
+// test/validate-record.test.mjs
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = fileURLToPath(new URL("../skills/triage/scripts/validate-record.mjs", import.meta.url));
+
+// Exit 1 (violations) is expected output, not a crash — capture both shapes.
+function run(args) {
+  try {
+    const stdout = execFileSync("node", [SCRIPT, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return { status: 0, stdout, stderr: "" };
+  } catch (e) {
+    return { status: e.status, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+function record(body) {
+  const dir = mkdtempSync(join(tmpdir(), "vr-"));
+  const file = join(dir, "rec.yaml");
+  writeFileSync(file, body);
+  return file;
+}
+
+const VALID = 'task: "Add SSO login"\nstatus: in_progress\ncreated: 2026-06-01\nphases:\n  - phase: X\n    status: pending\n';
+
+test("a schema-conformant record validates", () => {
+  const r = run(["--file", record(VALID)]);
+  assert.equal(r.status, 0);
+  assert.equal(r.stdout, "");
+});
+
+test("off-schema top-level status is a violation", () => {
+  const r = run(["--file", record('task: "X"\nstatus: implementation_complete\ncreated: 2026-06-01\n'), "--json"]);
+  assert.equal(r.status, 1);
+  const out = JSON.parse(r.stdout);
+  assert.equal(out.valid, false);
+  assert.ok(out.violations.some((v) => v.field === "status" && /off-schema/.test(v.message)));
+});
+
+test("created_at is reported as the wrong field name", () => {
+  const r = run(["--file", record('task: "X"\nstatus: in_progress\ncreated_at: 2026-05-22\n'), "--json"]);
+  assert.equal(r.status, 1);
+  const out = JSON.parse(r.stdout);
+  assert.ok(out.violations.some((v) => v.field === "created_at" && /`created`/.test(v.message)));
+});
+
+test("missing created and missing task are both reported", () => {
+  const r = run(["--file", record("status: in_progress\n"), "--json"]);
+  assert.equal(r.status, 1);
+  const fields = JSON.parse(r.stdout).violations.map((v) => v.field);
+  assert.ok(fields.includes("created"));
+  assert.ok(fields.includes("task"));
+});
+
+test("malformed created date is a violation", () => {
+  const r = run(["--file", record('task: "X"\nstatus: draft\ncreated: last tuesday\n'), "--json"]);
+  assert.equal(r.status, 1);
+  assert.ok(JSON.parse(r.stdout).violations.some((v) => v.field === "created" && /YYYY-MM-DD/.test(v.message)));
+});
+
+test("off-schema phase status is a violation", () => {
+  const body = 'task: "X"\nstatus: in_progress\ncreated: 2026-06-01\nphases:\n  - phase: A\n    status: in_review\n';
+  const r = run(["--file", record(body), "--json"]);
+  assert.equal(r.status, 1);
+  assert.ok(JSON.parse(r.stdout).violations.some((v) => v.field === "phases[].status" && v.value === "in_review"));
+});
+
+test("a known phase-status synonym names its canonical form", () => {
+  const body = 'task: "X"\nstatus: complete\ncreated: 2026-06-01\nphases:\n  - phase: A\n    status: completed\n';
+  const r = run(["--file", record(body), "--json"]);
+  assert.equal(r.status, 1);
+  const v = JSON.parse(r.stdout).violations.find((x) => x.value === "completed");
+  assert.match(v.message, /write "complete" instead/);
+});
+
+test("quoted values are accepted", () => {
+  const body = 'task: "X"\nstatus: "complete"\ncreated: "2026-06-01"\nphases:\n  - phase: A\n    status: "complete"\n';
+  assert.equal(run(["--file", record(body)]).status, 0);
+});
+
+test("human-readable output names the file and each violation", () => {
+  const file = record('task: "X"\nstatus: nope\ncreated: 2026-06-01\n');
+  const r = run(["--file", file]);
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /rec\.yaml/);
+  assert.match(r.stdout, /status \(nope\)/);
+});
+
+test("bad argv exits 2", () => {
+  assert.equal(run([]).status, 2);                                  // missing --file
+  assert.equal(run(["--file", "rel.yaml"]).status, 2);              // relative path
+  assert.equal(run(["--file", "/nope/missing.yaml"]).status, 2);    // unreadable
+  assert.equal(run(["--file", record(VALID), "--bogus"]).status, 2); // unknown arg
+});


### PR DESCRIPTION
## Changelog

### triage 1.0.0 → 1.1.0

- feat(triage): add /triage-cleanup for pruning stale records, specs, and plans
- feat(triage): add shared record parsing and a schema validator
- feat(triage): add SessionStart heartbeat
- refactor(triage): cut the always-loaded body to 9.4KB
- refactor(triage): move conditional phases into references
- refactor(triage): finish removing the flow-table scaffolding

### review-then-dry 1.0.1 → 1.1.0

- feat(review-then-dry): add standalone checklist-lifecycle skill + SessionStart heartbeat
- refactor(review-then-dry): split lifecycled-code-review, trim dry description
- chore(review-then-dry): drop refs to removed urchin skill

## Post-merge checklist

- [ ] Create git tags after merge (see below)
- [ ] Open sync PR from main → develop